### PR TITLE
SUP-8526 changed float formatting

### DIFF
--- a/sources/csharp/KalturaClient/KalturaParam.cs
+++ b/sources/csharp/KalturaClient/KalturaParam.cs
@@ -96,7 +96,7 @@ namespace Kaltura
                 case PARAM_TYPE_LONG:
                     return _LongValue.ToString();
                 case PARAM_TYPE_FLOAT:
-                    return String.Format("{0:F20}", _FloatValue);
+                    return _FloatValue.ToString();
                 case PARAM_TYPE_STRING:
                 default:
                     return "\"" + _Value.Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";


### PR DESCRIPTION
to avoid OS locale settings affect the number representation (comma as decimal separator breaks JSON structure, which causes the API to not be able to parse it).