### PR TITLE
do not declare GCC_VERSION = com.apple.compilers.llvmgcc42

### DIFF
--- a/sources/objc/KalturaClientTester/KalturaClientTester.xcodeproj/project.pbxproj
+++ b/sources/objc/KalturaClientTester/KalturaClientTester.xcodeproj/project.pbxproj
@@ -288,7 +288,6 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
@@ -305,7 +304,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;


### PR DESCRIPTION
it causes the following error:
"Unsupported compiler 'com.apple.compilers.llvmgcc42' selected for architecture 'i386'"

As can be seen in
https://travis-ci.org/kaltura/KalturaGeneratedAPIClientsObjectiveC/builds/166436718

When you don't declare anything, com.apple.compilers.llvm.clang.1_0.compiler will be used, which is fine.