### PR TITLE
secretForSigning is a native string, not String.

### DIFF
--- a/sources/csharp2/KalturaClient/ClientBase.cs
+++ b/sources/csharp2/KalturaClient/ClientBase.cs
@@ -164,7 +164,7 @@ namespace Kaltura
 		    return encodedKs;
         }
 	
-	    private byte[] aesEncrypt(String secretForSigning, byte[] text)
+	    private byte[] aesEncrypt(string secretForSigning, byte[] text)
         {
             byte[] hashedKey = signInfoWithSHA1(secretForSigning);
             byte[] keyBytes = new byte[BLOCK_SIZE];


### PR DESCRIPTION
Current code causes:
ClientBase.cs(167,32): error CS0104: `String' is an ambiguous reference between `string' and `Kaltura.Types.String'