### PR TITLE
Also catch non-KalturaObjectBase objects

### DIFF
--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -774,7 +774,7 @@ class KalturaClientBase
 			return;
 		}
 
-		if(!is_array($paramValue))
+		if(!is_array($paramValue) && !is_object($paramValue))
 		{
 			$params[$paramName] = (string)$paramValue;
 			return;


### PR DESCRIPTION
causes https://github.com/kaltura/server-saas-config/blob/6e1c12b62e58bcb47fbac8e17a4afae8e5587d4a/configurations/batch/live.workers.ini#L49 to error out as filter.KalturaCuePointFilter.cuePointTypeIn uses a non-KalturaObjectBase object. As a result the batch keeps restarting without throwing errors, causing a huge DB and Sphinx log growth. Must occur on SaaS as well, so probably good to implement asap