### PR TITLE
PLAT-7084  PHP53 client test failure

### DIFF
--- a/tests/ovp/php53/tests/Test/Zend2ClientTester.php
+++ b/tests/ovp/php53/tests/Test/Zend2ClientTester.php
@@ -176,7 +176,7 @@ class Zend2ClientTester
     	
     	// execute playlist from filters
     	$playlistFilter = new MediaEntryFilterForPlaylist();
-    	$playlistFilter->idEqual = $imageEntry->id;
+    	$playlistFilter->freeText = $imageEntry->id;
     	$filterArray = array();
     	$filterArray[] = $playlistFilter;
     	$playlistExecute = $this->_client->getPlaylistService()->executeFromFilters($filterArray, 10);


### PR DESCRIPTION
PLAT-7084  
The test includes filter with the syntax of idEqual which does not work with the executeFromFilter 
Instead using the freeText to get the list (same as the KMC does)