### PR TITLE
add proxyTunnel as a configurable value

### DIFF
--- a/sources/zend/Kaltura/Client/ClientBase.php
+++ b/sources/zend/Kaltura/Client/ClientBase.php
@@ -390,7 +390,7 @@ class Kaltura_Client_ClientBase
 		}
 
 		if (isset($this->config->proxyHost)) {
-			curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
+			curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, $this->config->proxyTunnel);
 			curl_setopt($ch, CURLOPT_PROXY, $this->config->proxyHost);
 			if (isset($this->config->proxyPort)) {
 				curl_setopt($ch, CURLOPT_PROXYPORT, $this->config->proxyPort);

--- a/sources/zend/Kaltura/Client/Configuration.php
+++ b/sources/zend/Kaltura/Client/Configuration.php
@@ -42,6 +42,7 @@ class Kaltura_Client_Configuration
 	public $proxyHost                   = null;
 	public $proxyPort                   = null;
 	public $proxyType                   = 'HTTP';
+	public $proxyTunnel                 = true;
 	public $proxyUser                   = null;
 	public $proxyPassword               = '';
 	public $verifySSL 					= true;


### PR DESCRIPTION
Some proxies may not want to tunnel; this change makes tunneling an optional value that can be overridden in the config object.