### PR TITLE
Fixed usage of class properties when setting request configuration

### DIFF
--- a/sources/php53/library/Kaltura/Client/Base.php
+++ b/sources/php53/library/Kaltura/Client/Base.php
@@ -443,6 +443,7 @@ class Base
 	public function setRequestConfiguration(\Kaltura\Client\Type\RequestConfiguration $configuration)
 	{
 		$params = get_class_vars('\Kaltura\Client\Type\RequestConfiguration');
+		$params = array_keys($params);
 		foreach($params as $param)
 		{
 			if(is_null($configuration->$param))


### PR DESCRIPTION
@tan-tan-kanarek, the code currently tries to use the value of class property, but it should be using the key.