### PR TITLE
check if $configuration->$param is empty before attemping is_null().

### DIFF
--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -706,12 +706,12 @@ class KalturaClientBase
 		$params = get_class_vars('KalturaClientConfiguration');
 		foreach($params as $param)
 		{
-			if(empty($configuration->$param) || is_null($configuration->$param))
+			if (empty($configuration->$param)){
+			    continue;
+			}
+			if(is_null($configuration->$param))
 			{
-				if(isset($this->clientConfiguration[$param]))
-				{
-					unset($this->clientConfiguration[$param]);
-				}
+			    	unset($this->clientConfiguration[$param]);
 			}
 			else
 			{

--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -704,17 +704,14 @@ class KalturaClientBase
 	public function setClientConfiguration(KalturaClientConfiguration $configuration)
 	{
 		$params = get_class_vars('KalturaClientConfiguration');
-		foreach($params as $param)
+		foreach($params as $param => $value)
 		{
-			if (empty($configuration->$param)){
-			    continue;
-			}
 			if(is_null($configuration->$param))
 			{
-			    if(isset($this->clientConfiguration[$param]))
-			    {
-				   unset($this->clientConfiguration[$param]);
-			    }
+				if(isset($this->clientConfiguration[$param]))
+				{
+					unset($this->clientConfiguration[$param]);
+				}
 			}
 			else
 			{
@@ -726,7 +723,7 @@ class KalturaClientBase
 	public function setRequestConfiguration(KalturaRequestConfiguration $configuration)
 	{
 		$params = get_class_vars('KalturaRequestConfiguration');
-		foreach($params as $param)
+		foreach($params as $param => $value)
 		{
 			if(is_null($configuration->$param))
 			{

--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -706,7 +706,7 @@ class KalturaClientBase
 		$params = get_class_vars('KalturaClientConfiguration');
 		foreach($params as $param)
 		{
-			if(is_null($configuration->$param))
+			if(empty($configuration->$param) || is_null($configuration->$param))
 			{
 				if(isset($this->clientConfiguration[$param]))
 				{

--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -711,7 +711,10 @@ class KalturaClientBase
 			}
 			if(is_null($configuration->$param))
 			{
-			    	unset($this->clientConfiguration[$param]);
+			    if(isset($this->clientConfiguration[$param]))
+			    {
+				   unset($this->clientConfiguration[$param]);
+			    }
 			}
 			else
 			{


### PR DESCRIPTION
Right now, if it's empty, one will get:
PHP Fatal error:  Uncaught Error: Cannot access empty property in
/opt/kaltura/app/tests/lib/KalturaClientBase.php:710