### PR TITLE
updates Java client to use 'Expect: 100-continue' header

### DIFF
--- a/sources/java/src/main/java/com/kaltura/client/KalturaClientBase.java
+++ b/sources/java/src/main/java/com/kaltura/client/KalturaClientBase.java
@@ -680,6 +680,9 @@ abstract public class KalturaClientBase implements Serializable {
 		allParts = parts.toArray(allParts);
 	 
 		method.setRequestEntity(new MultipartRequestEntity(allParts, method.getParams()));
+
+		// Ensures that request negotiation happens before the body is sent (preventing issues around uploads over HTTPS being rejected)
+		method.getParams().setBooleanParameter(HttpMethodParams.USE_EXPECT_CONTINUE, true);
  
 		return method;
 	}


### PR DESCRIPTION
Using the HttpClient `USE_EXPECT_CONTINUE` method param to true to ensure that the `Expect: 100-continue` http header gets sent for file upload requests.

This ensures that the request body is only sent after the server accepts the request headers (see http://hc.apache.org/httpclient-3.x/performance.html#Expect-continue_handshake). It also a 413 response code when uploading large files over https.