### PR TITLE
PS-3289 - Ignore empty plugins

### DIFF
--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -611,6 +611,9 @@ abstract class ClientGeneratorFromXml
 
 	protected function shouldAddPlugin(DOMElement $pluginNode)
 	{
+		if (!$this->_config->ignoreEmptyPlugins)
+			return true;
+
 		$xpath = new DOMXPath($this->_doc);
 		$pluginName = $pluginNode->getAttribute("name");
 		$serviceNodes = $xpath->query("/xml/services/service[@plugin = '$pluginName']");

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -608,4 +608,22 @@ abstract class ClientGeneratorFromXml
 	public function done($outputPath)
 	{
 	}
+
+	protected function shouldAddPlugin(DOMElement $pluginNode)
+	{
+		$xpath = new DOMXPath($this->_doc);
+		$pluginName = $pluginNode->getAttribute("name");
+		$serviceNodes = $xpath->query("/xml/services/service[@plugin = '$pluginName']");
+		if ($serviceNodes->length === 0)
+			return false;
+
+		$shouldAdd = false;
+		/** @var \DOMElement $serviceNode */
+		foreach($serviceNodes as $serviceNode)
+		{
+			if ($this->shouldIncludeService($serviceNode->getAttribute("id")))
+				$shouldAdd = true;
+		}
+		return $shouldAdd;
+	}
 }

--- a/lib/PhpZendClientGenerator.php
+++ b/lib/PhpZendClientGenerator.php
@@ -149,6 +149,9 @@ class PhpZendClientGenerator extends ClientGeneratorFromXml
 		$pluginNodes = $xpath->query("/xml/plugins/plugin");
 		foreach($pluginNodes as $pluginNode)
 		{
+			if (!$this->shouldAddPlugin($pluginNode))
+				continue;
+
 		    $this->writePlugin($pluginNode);
 		}
 	}


### PR DESCRIPTION
By default, empty plugin classes are generated. 
Added ability to ignore empty plugins. Similar behavior worked in the past. 
This is required in order to generate a minimal client lib for our Wordpress plugin.

_* Currently only implemented in Zend client_