### PR TITLE
PS-3289 - Ignore unrelated classes

### DIFF
--- a/config/generator.ini
+++ b/config/generator.ini
@@ -209,9 +209,9 @@ nopackage = true
 
 [wordpress: public]
 generator = PhpZendClientGenerator
-include = session.start, partner.getSecrets, partner.register, baseEntry.get, baseEntry.list, baseEntry.update, media.update, baseEntry.delete, category.list, system.ping, uiConf.list, uiConf.get, metadata_metadata.add, metadata_metadata.update, metadata_metadata.list, metadata_metadataProfile.list, metadata_metadataProfile.listFields
-ignore = KalturaFilter, KalturaUiConf, KalturaUiConfAdminBaseFilter, KalturaUiConfAdminFilter, KalturaResource, KalturaDataCenterContentResource, KalturaSearchItem
-ignoreExtends = KalturaListResponse, KalturaRelatedFilter
+include = session.start, partner.getSecrets, partner.register, baseEntry.get, baseEntry.list, baseEntry.update, playlist.list, playlist.execute, media.update, baseEntry.delete, category.list, system.ping, uiConf.list, uiConf.get, metadata_metadata.add, metadata_metadata.update, metadata_metadata.list, metadata_metadataProfile.list
+ignore = KalturaUiConfAdminBaseFilter, KalturaUiConfAdminFilter, KalturaForensicWatermarkAdvancedFilter
+ignoreExtends = KalturaListResponse, KalturaRelatedFilter, KalturaFilter
 ignoreEmptyPlugins = true
 additional = KalturaFilter, KalturaUiConf, KalturaSearchItem
 generateDocs = true

--- a/config/generator.ini
+++ b/config/generator.ini
@@ -206,3 +206,14 @@ nopackage = true
 generator = ErlangClientGenerator
 internal = true
 nopackage = true
+
+[wordpress: public]
+generator = PhpZendClientGenerator
+include = session.start, partner.getSecrets, partner.register, baseEntry.get, baseEntry.list, baseEntry.update, media.update, baseEntry.delete, category.list, system.ping, uiConf.list, uiConf.get, metadata_metadata.add, metadata_metadata.update, metadata_metadata.list, metadata_metadataProfile.list, metadata_metadataProfile.listFields
+ignore = KalturaFilter, KalturaUiConf, KalturaUiConfAdminBaseFilter, KalturaUiConfAdminFilter, KalturaResource, KalturaDataCenterContentResource, KalturaSearchItem
+ignoreExtends = KalturaListResponse, KalturaRelatedFilter
+ignoreEmptyPlugins = true
+additional = KalturaFilter, KalturaUiConf, KalturaSearchItem
+generateDocs = true
+package = Kaltura
+subpackage = Client

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -611,6 +611,9 @@ abstract class ClientGeneratorFromXml
 
 	protected function shouldAddPlugin(DOMElement $pluginNode)
 	{
+		if (!$this->_config->ignoreEmptyPlugins)
+			return true;
+
 		$xpath = new DOMXPath($this->_doc);
 		$pluginName = $pluginNode->getAttribute("name");
 		$serviceNodes = $xpath->query("/xml/services/service[@plugin = '$pluginName']");

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -32,7 +32,13 @@ abstract class ClientGeneratorFromXml
 	 * @var array
 	 */
 	protected $_ignoreTypes = null;
-	
+
+	/**
+	 * @var array
+	 */
+	protected $_ignoreExtends = array();
+
+
 	/**
 	 * @var array
 	 */
@@ -100,7 +106,12 @@ abstract class ClientGeneratorFromXml
 		$type = strval($type);
 		return !count($this->_includeTypes) || isset($this->_includeTypes[$type]);
 	}
-	
+
+	protected function shouldExtendType($type)
+	{
+		return (!in_array($type, $this->_ignoreExtends, true));
+	}
+
 	protected function shouldIncludeAction($serviceId, $actionId)
 	{
 		$serviceId = strtolower(strval($serviceId));
@@ -130,7 +141,10 @@ abstract class ClientGeneratorFromXml
 
 		if($this->_config->ignore)
 			$this->_ignoreTypes = explode(',', str_replace(' ', '', $this->_config->ignore));
-		
+
+		if($this->_config->ignoreExtends)
+			$this->_ignoreExtends = explode(',', str_replace(' ', '', $this->_config->ignoreExtends));
+
 		if($this->_config->include)
 		{
 			$includes = explode(',', str_replace(' ', '', $this->_config->include));
@@ -272,7 +286,7 @@ abstract class ClientGeneratorFromXml
 		}
 
 		$this->_includeTypes[$type] = $type;
-		if($classNode->hasAttribute("base"))
+		if($classNode->hasAttribute("base") && $this->shouldExtendType($type))
 			$this->loadTypesRecursive($classNode->getAttribute("base"));
 		
 		foreach($classNode->childNodes as $propertyNode)

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -286,7 +286,7 @@ abstract class ClientGeneratorFromXml
 		}
 
 		$this->_includeTypes[$type] = $type;
-		if($classNode->hasAttribute("base") && $this->shouldExtendType($type))
+		if($classNode->hasAttribute("base"))
 			$this->loadTypesRecursive($classNode->getAttribute("base"));
 		
 		foreach($classNode->childNodes as $propertyNode)
@@ -306,7 +306,9 @@ abstract class ClientGeneratorFromXml
 		$classNodes = $xpath->query("/xml/classes/class[@base = '$type']");
 		foreach($classNodes as $classNode)
 		{
-			$this->loadTypesRecursive($classNode->getAttribute("name"));
+			if ($this->shouldExtendType($type)) {
+				$this->loadTypesRecursive($classNode->getAttribute("name"));
+			}
 		}
 		
 		if($this->endsWith($type, 'Filter'))

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -608,4 +608,22 @@ abstract class ClientGeneratorFromXml
 	public function done($outputPath)
 	{
 	}
+
+	protected function shouldAddPlugin(DOMElement $pluginNode)
+	{
+		$xpath = new DOMXPath($this->_doc);
+		$pluginName = $pluginNode->getAttribute("name");
+		$serviceNodes = $xpath->query("/xml/services/service[@plugin = '$pluginName']");
+		if ($serviceNodes->length === 0)
+			return false;
+
+		$shouldAdd = false;
+		/** @var \DOMElement $serviceNode */
+		foreach($serviceNodes as $serviceNode)
+		{
+			if ($this->shouldIncludeService($serviceNode->getAttribute("id")))
+				$shouldAdd = true;
+		}
+		return $shouldAdd;
+	}
 }

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -303,10 +303,11 @@ abstract class ClientGeneratorFromXml
 			$this->loadTypesRecursive($propertyType);
 		}
 
-		$classNodes = $xpath->query("/xml/classes/class[@base = '$type']");
-		foreach($classNodes as $classNode)
+		if ($this->shouldExtendType($type))
 		{
-			if ($this->shouldExtendType($type)) {
+			$classNodes = $xpath->query("/xml/classes/class[@base = '$type']");
+			foreach ($classNodes as $classNode)
+			{
 				$this->loadTypesRecursive($classNode->getAttribute("name"));
 			}
 		}

--- a/lib/PhpZendClientGenerator.php
+++ b/lib/PhpZendClientGenerator.php
@@ -149,6 +149,9 @@ class PhpZendClientGenerator extends ClientGeneratorFromXml
 		$pluginNodes = $xpath->query("/xml/plugins/plugin");
 		foreach($pluginNodes as $pluginNode)
 		{
+			if (!$this->shouldAddPlugin($pluginNode))
+				continue;
+
 		    $this->writePlugin($pluginNode);
 		}
 	}


### PR DESCRIPTION
https://github.com/kaltura/clients-generator/pull/169 is included in this PR

When we add `KalturaListResponse` as [$alwaysAdd](https://github.com/kaltura/clients-generator/blob/214e872dcf42923cfa3059b59b63050c35bee946/lib/ClientGeneratorFromXml.php#L228-L233) type, it will also add all the classes that inherit from it, which leads to quite a lot of unneeded classes.

New option was added (`ignoreExtends`), that will bypass this behavior for the defined types.