### PR TITLE
fix '\' in json going to php

### DIFF
--- a/sources/csharp/KalturaClient/KalturaParam.cs
+++ b/sources/csharp/KalturaClient/KalturaParam.cs
@@ -110,7 +110,7 @@ namespace Kaltura
                     return String.Format(CultureInfo.InvariantCulture,"{0:F20}", _DoubleValue);
                 case PARAM_TYPE_STRING:
                 default:
-                    return "\"" + _Value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
+                    return "\"" + _Value.Replace("\\", "\\\\\\\\").Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
             }
         }
 

--- a/sources/csharp2/KalturaClient/Request/Param.cs
+++ b/sources/csharp2/KalturaClient/Request/Param.cs
@@ -100,7 +100,7 @@ namespace Kaltura.Request
                     return String.Format(CultureInfo.InvariantCulture,"{0:F20}", _FloatValue);
                 case PARAM_TYPE_STRING:
                 default:
-                    return "\"" + _Value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
+                    return "\"" + _Value.Replace("\\", "\\\\\\\\").Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
             }
         }
 


### PR DESCRIPTION
Fix handling of '\' which is going to be parsed in php.  
See https://stackoverflow.com/questions/32056940/how-to-deal-with-backslashes-in-json-strings-php

both JSON and PHP require escaping of the '\' so a single '\' should become '\\\\'