### PR TITLE
sending the UTF-8 encoded byteArray length to the post request stream…

### DIFF
--- a/sources/csharp2/KalturaClient/Request/BaseRequestBuilder.cs
+++ b/sources/csharp2/KalturaClient/Request/BaseRequestBuilder.cs
@@ -160,7 +160,7 @@ namespace Kaltura.Request
             if (getFiles().Count == 0)
             {
                 byte[] byteArray = Encoding.UTF8.GetBytes(json);
-                postStream.Write(byteArray, 0, json.Length);
+                postStream.Write(byteArray, 0, byteArray.Length);
             }
             else
             {


### PR DESCRIPTION
fix for: [VEON-408](https://kaltura.atlassian.net/browse/VEON-408)

… instead of json.length

this is due to the fact that when using UTF-8 characters  (e.g Cyrillic) the json.length != byteArray.length so the body is trimmed.