### PR TITLE
License "AGPL-3.0" is a deprecated SPDX license identifier, use

### DIFF
--- a/sources/php53/composer.json
+++ b/sources/php53/composer.json
@@ -3,7 +3,7 @@
     "description": "An auto generated Composer package for the Kaltura API client library",
     "keywords": ["kaltura", "client library", "video", "open source video", "video platform", "api"],
     "minimum-stability": "stable",
-    "license": "AGPL-3.0",
+    "license": "AGPL-3.0-or-later",
     "authors": [
         {
             "name": "Kaltura",


### PR DESCRIPTION
"AGPL-3.0-later"