### PR TITLE
Python cleanups

### DIFF
--- a/lib/PythonClientGenerator.php
+++ b/lib/PythonClientGenerator.php
@@ -71,7 +71,19 @@ class PythonClientGenerator extends ClientGeneratorFromXml
 					ucfirst($dependencyNode->getAttribute("pluginName")) . 
 					' import *');
 		}
-		$this->appendLine('from ..Base import *');
+		$this->appendLine('from ..Base import (');
+		$this->appendLine('    getXmlNodeBool,');
+		$this->appendLine('    getXmlNodeFloat,');
+		$this->appendLine('    getXmlNodeInt,');
+		$this->appendLine('    getXmlNodeText,');
+		$this->appendLine('    KalturaClientPlugin,');
+		$this->appendLine('    KalturaEnumsFactory,');
+		$this->appendLine('    KalturaFiles,');
+		$this->appendLine('    KalturaObjectBase,');
+		$this->appendLine('    KalturaObjectFactory,');
+		$this->appendLine('    KalturaParams,');
+		$this->appendLine('    KalturaServiceBase,');
+		$this->appendLine(')');
 		$this->appendLine('');
 
 		if ($pluginName == '')

--- a/lib/PythonClientGenerator.php
+++ b/lib/PythonClientGenerator.php
@@ -78,7 +78,6 @@ class PythonClientGenerator extends ClientGeneratorFromXml
 		$this->appendLine('    getXmlNodeText,');
 		$this->appendLine('    KalturaClientPlugin,');
 		$this->appendLine('    KalturaEnumsFactory,');
-		$this->appendLine('    KalturaFiles,');
 		$this->appendLine('    KalturaObjectBase,');
 		$this->appendLine('    KalturaObjectFactory,');
 		$this->appendLine('    KalturaParams,');
@@ -632,7 +631,6 @@ class PythonClientGenerator extends ClientGeneratorFromXml
 		    if ($haveFiles === false && $paramType == "file")
 	    	{
 		        $haveFiles = true;
-	        	$this->appendLine("        kfiles = KalturaFiles()");
 	    	}
 	    
 			switch ($paramType) 
@@ -657,7 +655,7 @@ class PythonClientGenerator extends ClientGeneratorFromXml
 					$this->appendLine("        kparams.addMapIfDefined(\"$paramName\", $argName)");
 					break;
 				case "file" :
-					$this->appendLine ( "        kfiles.put(\"$paramName\", " . $argName . ");" );
+					$this->appendLine ( "        kfiles = {\"$paramName\": " . $argName . "}" );
 					break;
 				default : // for objects
 					$this->appendLine("        kparams.addObjectIfDefined(\"$paramName\", $argName)");

--- a/sources/python/KalturaClient/Base.py
+++ b/sources/python/KalturaClient/Base.py
@@ -25,6 +25,10 @@
 #
 # @ignore
 # ===================================================================================================
+from __future__ import absolute_import
+
+from .exceptions import KalturaClientException
+
 import binascii
 import hashlib
 import json
@@ -316,34 +320,6 @@ class KalturaServiceBase(object):
     def setClient(self, client):
         self.client = client
 
-# Exception class for server errors
-class KalturaException(Exception):
-    def __init__(self, message, code):
-        self.code = code
-        self.message = message
-
-    def __str__(self):
-        return "%s (%s)" % (self.message, self.code)
-
-# Exception class for client errors
-class KalturaClientException(Exception):
-    ERROR_GENERIC = -1
-    ERROR_INVALID_XML = -2
-    ERROR_FORMAT_NOT_SUPPORTED = -3
-    ERROR_CONNECTION_FAILED = -4
-    ERROR_READ_FAILED = -5
-    ERROR_INVALID_PARTNER_ID = -6
-    ERROR_INVALID_OBJECT_TYPE = -7
-    ERROR_RESULT_NOT_FOUND = -8
-    ERROR_READ_TIMEOUT = -9
-    ERROR_READ_GZIP_FAILED = -10
-  
-    def __init__(self, message, code):
-        self.code = code
-        self.message = message
-
-    def __str__(self):
-        return "%s (%s)" % (self.message, self.code)
 
 # Client configuration class
 class KalturaConfiguration(object):

--- a/sources/python/KalturaClient/Base.py
+++ b/sources/python/KalturaClient/Base.py
@@ -1,12 +1,12 @@
-# ===================================================================================================
+# =============================================================================
 #                           _  __     _ _
 #                          | |/ /__ _| | |_ _  _ _ _ __ _
 #                          | ' </ _` | |  _| || | '_/ _` |
 #                          |_|\_\__,_|_|\__|\_,_|_| \__,_|
 #
 # This file is part of the Kaltura Collaborative Media Suite which allows users
-# to do with audio, video, and animation what Wiki platfroms allow them to do with
-# text.
+# to do with audio, video, and animation what Wiki platfroms allow them to do
+# with text.
 #
 # Copyright (C) 2006-2011  Kaltura Inc.
 #
@@ -24,7 +24,7 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 #
 # @ignore
-# ===================================================================================================
+# =============================================================================
 from __future__ import absolute_import
 
 from .exceptions import KalturaClientException
@@ -37,14 +37,16 @@ import six
 
 # Service response formats
 KALTURA_SERVICE_FORMAT_JSON = 1
-KALTURA_SERVICE_FORMAT_XML  = 2
-KALTURA_SERVICE_FORMAT_PHP  = 3
+KALTURA_SERVICE_FORMAT_XML = 2
+KALTURA_SERVICE_FORMAT_PHP = 3
+
 
 # Xml utility functions
 def getXmlNodeText(xmlNode):
-    if xmlNode.firstChild == None:
+    if xmlNode.firstChild is None:
         return ''
     return xmlNode.firstChild.nodeValue
+
 
 def getXmlNodeBool(xmlNode):
     text = getXmlNodeText(xmlNode)
@@ -53,6 +55,7 @@ def getXmlNodeBool(xmlNode):
     elif text == '1':
         return True
     return None
+
 
 def getXmlNodeInt(xmlNode):
     text = getXmlNodeText(xmlNode)
@@ -63,6 +66,7 @@ def getXmlNodeInt(xmlNode):
     except ValueError:
         return None
 
+
 def getXmlNodeFloat(xmlNode):
     text = getXmlNodeText(xmlNode)
     if text == '':
@@ -72,6 +76,7 @@ def getXmlNodeFloat(xmlNode):
     except ValueError:
         return None
 
+
 def getChildNodeByXPath(node, nodePath):
     for curName in nodePath.split('/'):
         nextChild = None
@@ -79,10 +84,11 @@ def getChildNodeByXPath(node, nodePath):
             if childNode.nodeName == curName:
                 nextChild = childNode
                 break
-        if nextChild == None:
+        if nextChild is None:
             return None
         node = nextChild
     return node
+
 
 # Request parameters container
 class KalturaParams(object):
@@ -92,8 +98,8 @@ class KalturaParams(object):
     def get(self):
         return self.params
 
-    def put(self, key, value = None):
-        if value == None:
+    def put(self, key, value=None):
+        if value is None:
             self.params[key + '__null'] = ''
         elif isinstance(value, six.binary_type):
             self.params[key] = value.decode('utf8')
@@ -107,17 +113,17 @@ class KalturaParams(object):
         self.params[key] = objectProps
 
     def addObjectIfDefined(self, key, obj):
-        if obj == NotImplemented:
+        if obj is NotImplemented:
             return
-        if obj == None:
+        if obj is None:
             self.put(key)
             return
         self.add(key, obj.toParams().get())
 
     def addArrayIfDefined(self, key, array):
-        if array == NotImplemented:
+        if array is NotImplemented:
             return
-        if array == None:
+        if array is None:
             self.put(key)
             return
         if len(array) == 0:
@@ -128,32 +134,32 @@ class KalturaParams(object):
                 arr.append(array[curIndex].toParams().get())
             self.params[key] = arr
 
-    def addMapIfDefined(self, key, map):
-        if map == NotImplemented:
+    def addMapIfDefined(self, key, map_):
+        if map_ is NotImplemented:
             return
-        if map == None:
+        if map_ is None:
             self.put(key)
             return
-        if len(map) == 0:
+        if len(map_) == 0:
             self.params[key] = {'-': ''}
         else:
             dic = {}
-            for currentKey in map:
-                dic[currentKey] = map[currentKey].toParams().get()
+            for currentKey in map_:
+                dic[currentKey] = map_[currentKey].toParams().get()
             self.params[key] = dic
-			
+
     def addStringIfDefined(self, key, value):
-        if value != NotImplemented:
+        if value is not NotImplemented:
             self.put(key, value)
 
     def addIntIfDefined(self, key, value):
-        if value != NotImplemented:
+        if value is not NotImplemented:
             self.put(key, value)
 
     def addStringEnumIfDefined(self, key, value):
-        if value == NotImplemented:
+        if value is NotImplemented:
             return
-        if value == None:
+        if value is None:
             self.put(key)
             return
         if type(value) == str:
@@ -162,9 +168,9 @@ class KalturaParams(object):
             self.addStringIfDefined(key, value.getValue())
 
     def addIntEnumIfDefined(self, key, value):
-        if value == NotImplemented:
+        if value is NotImplemented:
             return
-        if value == None:
+        if value is None:
             self.put(key)
             return
         if type(value) == int:
@@ -173,13 +179,13 @@ class KalturaParams(object):
             self.addIntIfDefined(key, value.getValue())
 
     def addFloatIfDefined(self, key, value):
-        if value != NotImplemented:
+        if value is not NotImplemented:
             self.put(key, value)
 
     def addBoolIfDefined(self, key, value):
-        if value == NotImplemented:
+        if value is NotImplemented:
             return
-        if value == None:
+        if value is None:
             self.put(key)
             return
         self.put(key, value)
@@ -188,19 +194,17 @@ class KalturaParams(object):
         for key in params:
             if isinstance(params[key], dict):
                 params[key] = self.sort(params[key])
-                
         sortedKeys = sorted(params.keys(), key=lambda x: six.text_type(x))
         sortedDict = {}
         for key in sortedKeys:
             sortedDict[key] = params[key]
-            
         return sortedDict
-        
+
     def toJson(self):
         return json.dumps(self.params)
-        
-    def signature(self, params = None):
-        if params == None:
+
+    def signature(self, params=None):
+        if params is None:
             params = self.params
         params = self.sort(params)
         return self.md5(self.toJson())
@@ -211,6 +215,7 @@ class KalturaParams(object):
         m.update(
             str_ if isinstance(str_, six.binary_type) else str_.encode("utf8"))
         return binascii.hexlify(m.digest())
+
 
 # Request files container
 class KalturaFiles(object):
@@ -226,6 +231,7 @@ class KalturaFiles(object):
     def update(self, props):
         self.params.update(props)
 
+
 # Kaltura objects factory
 class KalturaObjectFactory(object):
     objectFactories = {}
@@ -234,14 +240,16 @@ class KalturaObjectFactory(object):
     def create(objectNode, expectedTypeName):
         expectedType = KalturaObjectFactory.objectFactories[expectedTypeName]
         objTypeNode = getChildNodeByXPath(objectNode, 'objectType')
-        if objTypeNode == None:
+        if objTypeNode is None:
             return None
         objType = getXmlNodeText(objTypeNode)
         if objType not in KalturaObjectFactory.objectFactories:
-            objType = expectedType.__name__        
+            objType = expectedType.__name__
         result = KalturaObjectFactory.objectFactories[objType]()
         if not isinstance(result, expectedType):
-            raise KalturaClientException("Unexpected object type '%s'" % objType, KalturaClientException.ERROR_INVALID_OBJECT_TYPE)
+            raise KalturaClientException(
+                "Unexpected object type '%s'" % objType,
+                KalturaClientException.ERROR_INVALID_OBJECT_TYPE)
         result.fromXml(objectNode)
         return result
 
@@ -249,7 +257,8 @@ class KalturaObjectFactory(object):
     def createArray(arrayNode, expectedElemType):
         results = []
         for arrayElemNode in arrayNode.childNodes:
-            results.append(KalturaObjectFactory.create(arrayElemNode, expectedElemType))
+            results.append(
+                KalturaObjectFactory.create(arrayElemNode, expectedElemType))
         return results
 
     @staticmethod
@@ -258,27 +267,28 @@ class KalturaObjectFactory(object):
         for mapElemNode in mapNode.childNodes:
             keyNode = getChildNodeByXPath(mapElemNode, 'itemKey')
             key = getXmlNodeText(keyNode)
-            results[key] = KalturaObjectFactory.create(mapElemNode, expectedElemType)
+            results[key] = KalturaObjectFactory.create(
+                mapElemNode, expectedElemType)
         return results
 
     @staticmethod
     def registerObjects(objs):
         KalturaObjectFactory.objectFactories.update(objs)
 
+
 # Abstract base class for all client objects
 class KalturaObjectBase(object):
-    def __init__(self, 
-            relatedObjects=NotImplemented):
+    def __init__(self, relatedObjects=NotImplemented):
 
         # @var map of KalturaListResponse
         # @readonly
         self.relatedObjects = relatedObjects
-        
-        from KalturaClient.Plugins.Core import KalturaListResponse
+
         KalturaObjectBase.PROPERTY_LOADERS = {
-            'relatedObjects': (KalturaObjectFactory.createMap, 'KalturaListResponse') 
+            'relatedObjects': (
+                KalturaObjectFactory.createMap, 'KalturaListResponse')
         }
-    
+
     def fromXmlImpl(self, node, propList):
         for childNode in node.childNodes:
             nodeName = childNode.nodeName
@@ -287,7 +297,6 @@ class KalturaObjectBase(object):
                 propName += "_"
                 if propName not in propList:
                     continue
-					
             propLoader = propList[propName]
             if type(propLoader) == tuple:
                 (func, param) = propLoader
@@ -299,8 +308,7 @@ class KalturaObjectBase(object):
 
     def fromXml(self, node):
         self.fromXmlImpl(node, KalturaObjectBase.PROPERTY_LOADERS)
-        pass
-    
+
     def toParams(self):
         result = KalturaParams()
         result.put('objectType', 'KalturaObjectBase')
@@ -312,11 +320,13 @@ class KalturaObjectBase(object):
     def setRelatedObjects(self, newRelatedObjects):
         self.relatedObjects = newRelatedObjects
 
+
 # Abstract base class for all client services
 class KalturaServiceBase(object):
-    def __init__(self, client = None):
+
+    def __init__(self, client=None):
         self.client = client
-        
+
     def setClient(self, client):
         self.client = client
 
@@ -324,38 +334,41 @@ class KalturaServiceBase(object):
 # Client configuration class
 class KalturaConfiguration(object):
     # Constructs new Kaltura configuration object
-    def __init__(self, serviceUrl = "http://www.kaltura.com", logger = None):
-        self.logger                     = logger
-        self.serviceUrl                 = serviceUrl
-        self.format                     = KALTURA_SERVICE_FORMAT_XML
-        self.requestTimeout             = 120
-        
+    def __init__(self, serviceUrl="http://www.kaltura.com", logger=None):
+        self.logger = logger
+        self.serviceUrl = serviceUrl
+        self.format = KALTURA_SERVICE_FORMAT_XML
+        self.requestTimeout = 120
+
     # Set logger to get kaltura client debug logs
     def setLogger(self, log):
         self.logger = log
-        
+
     # Gets the logger (internal client use)
     def getLogger(self):
         return self.logger
+
 
 # Client plugin interface class
 class IKalturaClientPlugin(object):
     # @return KalturaClientPlugin
     @staticmethod
     def get():
-        raise NotImplementedError
-        
+        raise NotImplementedError()
+
     # @return array<KalturaServiceBase>
     def getServices(self):
-        raise NotImplementedError
-        
+        raise NotImplementedError()
+
     # @return string
     def getName(self):
-        raise NotImplementedError
-        
+        raise NotImplementedError()
+
+
 # Client plugin base class
 class KalturaClientPlugin(IKalturaClientPlugin):
     pass
+
 
 # Kaltura enums factory
 class KalturaEnumsFactory(object):
@@ -364,13 +377,15 @@ class KalturaEnumsFactory(object):
     @staticmethod
     def create(enumValue, enumType):
         if enumType not in KalturaEnumsFactory.enumFactories:
-            raise KalturaClientException("Unrecognized enum '%s'" % enumType, KalturaClientException.ERROR_INVALID_OBJECT_TYPE)
+            raise KalturaClientException(
+                "Unrecognized enum '%s'" % enumType,
+                KalturaClientException.ERROR_INVALID_OBJECT_TYPE)
         return KalturaEnumsFactory.enumFactories[enumType](enumValue)
 
     @staticmethod
     def createInt(enumNode, enumType):
         enumValue = getXmlNodeInt(enumNode)
-        if enumValue == None:
+        if enumValue is None:
             return None
         return KalturaEnumsFactory.create(enumValue, enumType)
 
@@ -385,7 +400,8 @@ class KalturaEnumsFactory(object):
     def registerEnums(objs):
         KalturaEnumsFactory.enumFactories.update(objs)
 
+
 # Implement to get Kaltura Client logs
 class IKalturaLogger(object):
     def log(self, msg):
-        raise NotImplementedError
+        raise NotImplementedError()

--- a/sources/python/KalturaClient/Base.py
+++ b/sources/python/KalturaClient/Base.py
@@ -209,21 +209,6 @@ class KalturaParams(object):
         return binascii.hexlify(m.digest())
 
 
-# Request files container
-class KalturaFiles(object):
-    def __init__(self):
-        self.params = {}
-
-    def get(self):
-        return self.params
-
-    def put(self, key, value):
-        self.params[key] = value
-
-    def update(self, props):
-        self.params.update(props)
-
-
 # Kaltura objects factory
 class KalturaObjectFactory(object):
     objectFactories = {}

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -49,7 +49,6 @@ import hashlib
 import mimetypes
 import random
 import base64
-import urllib
 import types
 import time
 import os

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -27,9 +27,24 @@
 # =============================================================================
 from __future__ import absolute_import
 
-from .Plugins.Core import *
-from .Base import *
-from .exceptions import KalturaClientException
+
+from KalturaClient.Base import (
+    IKalturaClientPlugin,
+    IKalturaLogger,
+    KALTURA_SERVICE_FORMAT_XML,
+    KalturaEnumsFactory,
+    KalturaFiles,
+    KalturaObjectBase,
+    KalturaObjectFactory,
+    KalturaParams,
+    getChildNodeByXPath,
+    getXmlNodeFloat,
+    getXmlNodeText,
+)
+from KalturaClient.exceptions import (
+    KalturaException, KalturaClientException)
+from KalturaClient.Plugins.Core import (
+    API_VERSION, KalturaClientConfiguration, KalturaRequestConfiguration)
 
 from xml.parsers.expat import ExpatError
 from xml.dom import minidom
@@ -52,9 +67,6 @@ try:
     from Crypto.Cipher import AES
 except ImportError:
     pass            # PyCrypto is required only for creating KS V2
-
-from KalturaClient.Plugins.Core import KalturaClientConfiguration
-from KalturaClient.Plugins.Core import KalturaRequestConfiguration
 
 
 def _get_file_params(files):

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -1,12 +1,12 @@
-# ===================================================================================================
+# =============================================================================
 #                           _  __     _ _
 #                          | |/ /__ _| | |_ _  _ _ _ __ _
 #                          | ' </ _` | |  _| || | '_/ _` |
 #                          |_|\_\__,_|_|\__|\_,_|_| \__,_|
 #
 # This file is part of the Kaltura Collaborative Media Suite which allows users
-# to do with audio, video, and animation what Wiki platfroms allow them to do with
-# text.
+# to do with audio, video, and animation what Wiki platfroms allow them to do
+# with text.
 #
 # Copyright (C) 2006-2011  Kaltura Inc.
 #
@@ -24,7 +24,7 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 #
 # @ignore
-# ===================================================================================================
+# =============================================================================
 from __future__ import absolute_import
 
 from .Plugins.Core import *
@@ -70,30 +70,37 @@ def _get_file_params(files):
 
 
 class MultiRequestSubResult(object):
+
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return '{%s}' % self.value
+
     def __repr__(self):
         return '{%s}' % self.value
+
     def __getattr__(self, name):
         if name.startswith('__') or name.endswith('__'):
-            raise AttributeError
+            raise AttributeError()
         return MultiRequestSubResult('%s:%s' % (self.value, name))
+
     def __getitem__(self, key):
         return MultiRequestSubResult('%s:%s' % (self.value, key))
+
 
 class PluginServicesProxy(object):
     def addService(self, serviceName, serviceClass):
         setattr(self, serviceName, serviceClass)
 
+
 class KalturaClient(object):
     RANDOM_SIZE = 16
 
-    FIELD_EXPIRY =              '_e'
-    FIELD_TYPE =                '_t'
-    FIELD_USER =                '_u'
-    ENCODING =                  'utf8'
+    FIELD_EXPIRY = '_e'
+    FIELD_TYPE = '_t'
+    FIELD_USER = '_u'
+    ENCODING = 'utf8'
 
     def __init__(self, config):
         self.config = None
@@ -102,9 +109,9 @@ class KalturaClient(object):
         self.callsQueue = []
         self.requestHeaders = {}
         self.clientConfiguration = {
-			'clientTag': 'python-@DATE@',
-			'apiVersion': API_VERSION,
-		}
+            'clientTag': 'python-@DATE@',
+            'apiVersion': API_VERSION,
+        }
         self.requestConfiguration = {}
 
         self.config = config
@@ -112,29 +119,33 @@ class KalturaClient(object):
         if (logger):
             self.shouldLog = True
 
-        KalturaObjectFactory.registerObjects({'KalturaObjectBase': KalturaObjectBase})
-		
+        KalturaObjectFactory.registerObjects(
+            {'KalturaObjectBase': KalturaObjectBase})
         self.loadPlugins()
         self.loadConfigurations()
 
-    def loadConfigurationItem(self, configurationMap, property):
-        ucfirst = property[0].upper() + property[1:]
-        setter = lambda self, value: configurationMap.update({property: value})
+    def loadConfigurationItem(self, configurationMap, property_):
+        ucfirst = property_[0].upper() + property_[1:]
+        setter = lambda self, value: configurationMap.update(
+            {property_: value})
         setattr(self, 'set' + ucfirst, types.MethodType(setter, self))
-        getter = lambda self: configurationMap[property]
+        getter = lambda self: configurationMap[property_]
         setattr(self, 'get' + ucfirst, types.MethodType(getter, self))
 
     def loadConfiguration(self, configurationClass, configurationMap):
-        for property in configurationClass.PROPERTY_LOADERS:
-            self.loadConfigurationItem(configurationMap, property)
+        for property_ in configurationClass.PROPERTY_LOADERS:
+            self.loadConfigurationItem(configurationMap, property_)
 
     def loadConfigurations(self):
-        self.loadConfiguration(KalturaClientConfiguration, self.clientConfiguration)
-        self.loadConfiguration(KalturaRequestConfiguration, self.requestConfiguration)
-        
+        self.loadConfiguration(
+            KalturaClientConfiguration, self.clientConfiguration)
+        self.loadConfiguration(
+            KalturaRequestConfiguration, self.requestConfiguration)
+
     def loadPlugins(self):
         pluginFiles = ['Core']
-        pluginsFolder = os.path.normpath(os.path.join(os.path.dirname(__file__), 'Plugins'))
+        pluginsFolder = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), 'Plugins'))
         if os.path.isdir(pluginsFolder):
             for fileName in os.listdir(pluginsFolder):
                 (pluginFile, fileExt) = os.path.splitext(fileName)
@@ -155,9 +166,9 @@ class KalturaClient(object):
             pluginClass = 'KalturaCoreClient'
         else:
             pluginClass = 'Kaltura%sClientPlugin' % pluginFile
-        if not pluginClass in dir(pluginModule):
+        if pluginClass not in dir(pluginModule):
             return
-        
+
         pluginClassType = getattr(pluginModule, pluginClass)
 
         plugin = pluginClassType.get()
@@ -196,20 +207,22 @@ class KalturaClient(object):
         # reset state
         self.callsQueue = []
 
-        if params != None:
+        if params is not None:
             result += '?' + six.moves.urllib.parse.urlencode(params.get())
         self.log("Returned url [%s]" % result)
-        return result        
-        
-    def queueServiceActionCall(self, service, action, returnType, params = KalturaParams(), files = KalturaFiles()):
+        return result
+
+    def queueServiceActionCall(self, service, action, returnType,
+                               params=KalturaParams(), files=KalturaFiles()):
         for param in self.requestConfiguration:
             if isinstance(self.requestConfiguration[param], KalturaObjectBase):
-                params.addObjectIfDefined(param, self.requestConfiguration[param])
+                params.addObjectIfDefined(
+                    param, self.requestConfiguration[param])
             else:
                 params.put(param, self.requestConfiguration[param])
-                
+
         call = KalturaServiceActionCall(service, action, params, files)
-        if(self.multiRequestReturnType != None):
+        if (self.multiRequestReturnType is not None):
             self.multiRequestReturnType.append(returnType)
         self.callsQueue.append(call)
 
@@ -220,7 +233,7 @@ class KalturaClient(object):
             params.put(param, self.clientConfiguration[param])
         params.put("format", self.config.format)
         url = self.config.serviceUrl + "/api_v3"
-        if (self.multiRequestReturnType != None):
+        if (self.multiRequestReturnType is not None):
             url += "/service/multirequest"
             i = 0
             for call in self.callsQueue:
@@ -285,7 +298,7 @@ class KalturaClient(object):
                 e, KalturaClientException.ERROR_READ_FAILED)
 
     # Send http request
-    def doHttpRequest(self, url, params = KalturaParams(), files = KalturaFiles()):
+    def doHttpRequest(self, url, params=KalturaParams(), files=KalturaFiles()):
         if len(files.get()) == 0:
             requestTimeout = self.config.requestTimeout
         else:
@@ -296,29 +309,32 @@ class KalturaClient(object):
         data = self.readHttpResponse(r)
         self.responseHeaders = r.headers
         return data
-        
+
     def parsePostResult(self, postResult):
         if len(postResult) > 1024:
             self.log("result (xml): %s bytes" % len(postResult))
         else:
             self.log("result (xml): %s" % postResult)
 
-        try:        
+        try:
             resultXml = minidom.parseString(postResult)
         except ExpatError as e:
-            raise KalturaClientException(e, KalturaClientException.ERROR_INVALID_XML)
-            
+            raise KalturaClientException(
+                e, KalturaClientException.ERROR_INVALID_XML)
+
         resultNode = getChildNodeByXPath(resultXml, 'xml/result')
-        if resultNode == None:
-            raise KalturaClientException('Could not find result node in response xml', KalturaClientException.ERROR_RESULT_NOT_FOUND)
+        if resultNode is None:
+            raise KalturaClientException(
+                'Could not find result node in response xml',
+                KalturaClientException.ERROR_RESULT_NOT_FOUND)
 
         execTime = getChildNodeByXPath(resultXml, 'xml/executionTime')
-        if execTime != None:
+        if execTime is not None:
             self.executionTime = getXmlNodeFloat(execTime)
 
         self.throwExceptionIfError(resultNode)
-        return resultNode        
-        
+        return resultNode
+
     # Call all API services that are in queue
     def doQueue(self):
         self.responseHeaders = None
@@ -328,17 +344,19 @@ class KalturaClient(object):
             return None
 
         if self.config.format != KALTURA_SERVICE_FORMAT_XML:
-            raise KalturaClientException("unsupported format: %s" % (postResult), KalturaClientException.ERROR_FORMAT_NOT_SUPPORTED)
-            
+            raise KalturaClientException(
+                "unsupported format: %s" % (postResult),
+                KalturaClientException.ERROR_FORMAT_NOT_SUPPORTED)
+
         startTime = time.time()
 
         # get request params
-        (url, params, files) = self.getRequestParams()        
-            
+        (url, params, files) = self.getRequestParams()
+
         # reset state
         self.callsQueue = []
-        
-        # issue the request        
+
+        # issue the request
         postResult = self.doHttpRequest(url, params, files)
 
         endTime = time.time()
@@ -352,88 +370,101 @@ class KalturaClient(object):
                 serverName = curHeader.split(':', 1)[1].strip()
             elif curHeader.startswith('X-Kaltura-Session:'):
                 serverSession = curHeader.split(':', 1)[1].strip()
-        if serverName != None or serverSession != None:
-            self.log("server: [%s], session [%s]" % (serverName, serverSession))
+        if serverName is not None or serverSession is not None:
+            self.log(
+                "server: [%s], session [%s]" % (serverName, serverSession))
 
         # parse the result
         resultNode = self.parsePostResult(postResult)
 
         return resultNode
-        
+
     def getConfig(self):
         return self.config
-        
+
     def setConfig(self, config):
         self.config = config
         logger = self.config.getLogger()
         if isinstance(logger, IKalturaLogger):
             self.shouldLog = True
-        
+
     def getExceptionIfError(self, resultNode):
         errorNode = getChildNodeByXPath(resultNode, 'error')
-        if errorNode == None:
+        if errorNode is None:
             return None
         messageNode = getChildNodeByXPath(errorNode, 'message')
         codeNode = getChildNodeByXPath(errorNode, 'code')
-        if messageNode == None or codeNode == None:
+        if messageNode is None or codeNode is None:
             return None
-        return KalturaException(getXmlNodeText(messageNode), getXmlNodeText(codeNode))
+        return KalturaException(
+            getXmlNodeText(messageNode), getXmlNodeText(codeNode))
 
     # Validate the result xml node and raise exception if its an error
     def throwExceptionIfError(self, resultNode):
         exceptionObj = self.getExceptionIfError(resultNode)
-        if exceptionObj == None:
+        if exceptionObj is None:
             return
         raise exceptionObj
 
     def startMultiRequest(self):
         self.multiRequestReturnType = []
-        
+
     def doMultiRequest(self):
         resultXml = self.doQueue()
-        if resultXml == None:
+        if resultXml is None:
             return []
         result = []
         i = 0
         for childNode in resultXml.childNodes:
             exceptionObj = self.getExceptionIfError(childNode)
-            if exceptionObj != None:
+            if exceptionObj is not None:
                 result.append(exceptionObj)
-            elif getChildNodeByXPath(childNode, 'objectType') != None:
-                result.append(KalturaObjectFactory.create(childNode, self.multiRequestReturnType[i]))
-            elif getChildNodeByXPath(childNode, 'item/objectType') != None:
-                result.append(KalturaObjectFactory.createArray(childNode, self.multiRequestReturnType[i]))
+            elif getChildNodeByXPath(childNode, 'objectType') is not None:
+                result.append(
+                    KalturaObjectFactory.create(
+                        childNode, self.multiRequestReturnType[i]))
+            elif getChildNodeByXPath(childNode, 'item/objectType') is not None:
+                result.append(
+                    KalturaObjectFactory.createArray(
+                        childNode, self.multiRequestReturnType[i]))
             else:
                 result.append(getXmlNodeText(childNode))
-            i+=1
+            i += 1
         self.multiRequestReturnType = None
         return result
 
     def isMultiRequest(self):
-        return (self.multiRequestReturnType != None)
-        
+        return (self.multiRequestReturnType is not None)
+
     def getMultiRequestResult(self):
         return MultiRequestSubResult('%s:result' % len(self.callsQueue))
-        
+
     def log(self, msg):
         if self.shouldLog:
             self.config.getLogger().log(msg)
 
     @staticmethod
-    def generateSession(adminSecretForSigning, userId, type_, partnerId, expiry = 86400, privileges = ''):
+    def generateSession(adminSecretForSigning, userId, type_, partnerId,
+                        expiry=86400, privileges=''):
         rand = random.randint(0, 0x10000)
         expiry = int(time.time()) + expiry
-        fields = [partnerId, partnerId, expiry, type_, rand, userId, privileges]
-        fields = [x if isinstance(x, six.binary_type) else six.text_type(x).encode(KalturaClient.ENCODING) for x in fields]
+        fields = [
+            partnerId, partnerId, expiry, type_, rand, userId, privileges]
+        fields = [
+            x if isinstance(x, six.binary_type)
+            else six.text_type(x).encode(KalturaClient.ENCODING)
+            for x in fields]
         info = six.b(';').join(fields)
         signature = binascii.hexlify(
-            KalturaClient.hash(adminSecretForSigning.encode(KalturaClient.ENCODING) + info))
+            KalturaClient.hash(
+                adminSecretForSigning.encode(KalturaClient.ENCODING) + info))
         decodedKS = signature + six.b("|") + info
         KS = base64.b64encode(decodedKS)
         return KS
 
     @staticmethod
-    def generateSessionV2(adminSecretForSigning, userId, type, partnerId, expiry = 86400, privileges = ''):
+    def generateSessionV2(adminSecretForSigning, userId, type, partnerId,
+                          expiry=86400, privileges=''):
         # build fields array
         fields = {}
         for privilege in privileges.split(','):
@@ -453,16 +484,23 @@ class KalturaClient(object):
         fields[KalturaClient.FIELD_USER] = str(userId)
 
         # build fields string
-        fieldsStr = six.moves.urllib.parse.urlencode(fields).encode(KalturaClient.ENCODING)
-        fieldsStr = Random.get_random_bytes(KalturaClient.RANDOM_SIZE) + fieldsStr
+        fieldsStr = six.moves.urllib.parse.urlencode(fields).encode(
+            KalturaClient.ENCODING)
+        fieldsStr = Random.get_random_bytes(
+            KalturaClient.RANDOM_SIZE) + fieldsStr
         fieldsStr = KalturaClient.hash(fieldsStr) + fieldsStr
 
         # encrypt and encode
-        cipher = AES.new(KalturaClient.hash(adminSecretForSigning.encode(KalturaClient.ENCODING))[:16], AES.MODE_CBC, six.b('\0') * 16)
+        cipher = AES.new(
+            KalturaClient.hash(
+                adminSecretForSigning.encode(KalturaClient.ENCODING))[:16],
+            AES.MODE_CBC, six.b('\0') * 16)
         if len(fieldsStr) % cipher.block_size != 0:
-            fieldsStr += six.b('\0') * (cipher.block_size - len(fieldsStr) % cipher.block_size)
+            fieldsStr += six.b('\0') * (
+                cipher.block_size - len(fieldsStr) % cipher.block_size)
         encryptedFields = cipher.encrypt(fieldsStr)
-        decodedKs = ("v2|%s|" % partnerId).encode(KalturaClient.ENCODING) + encryptedFields
+        decodedKs = ("v2|%s|" % partnerId).encode(
+            KalturaClient.ENCODING) + encryptedFields
         return base64.urlsafe_b64encode(decodedKs)
 
     @staticmethod
@@ -471,18 +509,21 @@ class KalturaClient(object):
         m.update(msg)
         return m.digest()
 
+
 class KalturaServiceActionCall(object):
-    def __init__(self, service, action, params = KalturaParams(), files = KalturaFiles()):
+
+    def __init__(self, service, action, params=KalturaParams(),
+                 files=KalturaFiles()):
         self.service = service
         self.action = action
         self.params = params
         self.files = files
-        
+
     # Return the parameters for a multi request
     def getParamsForMultiRequest(self, multiRequestIndex):
         self.params.put('service', self.service)
         self.params.put('action', self.action)
-        
+
         multiRequestParams = KalturaParams()
         multiRequestParams.add(multiRequestIndex, self.params.get())
         return multiRequestParams.get()

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -29,6 +29,8 @@ from __future__ import absolute_import
 
 from .Plugins.Core import *
 from .Base import *
+from .exceptions import KalturaClientException
+
 from xml.parsers.expat import ExpatError
 from xml.dom import minidom
 import binascii

--- a/sources/python/KalturaClient/exceptions.py
+++ b/sources/python/KalturaClient/exceptions.py
@@ -1,0 +1,62 @@
+# =============================================================================
+#                           _  __     _ _
+#                          | |/ /__ _| | |_ _  _ _ _ __ _
+#                          | ' </ _` | |  _| || | '_/ _` |
+#                          |_|\_\__,_|_|\__|\_,_|_| \__,_|
+#
+# This file is part of the Kaltura Collaborative Media Suite which allows users
+# to do with audio, video, and animation what Wiki platfroms allow them to do
+# with text.
+#
+# Copyright (C) 2006-2017  Kaltura Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http:#www.gnu.org/licenses/>.
+#
+# @ignore
+# =============================================================================
+
+
+class KalturaException(Exception):
+
+    """Exception class for server errors."""
+
+    def __init__(self, message, code):
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return "%s (%s)" % (self.message, self.code)
+
+
+class KalturaClientException(Exception):
+
+    """Exception class for client errors."""
+
+    ERROR_GENERIC = -1
+    ERROR_INVALID_XML = -2
+    ERROR_FORMAT_NOT_SUPPORTED = -3
+    ERROR_CONNECTION_FAILED = -4
+    ERROR_READ_FAILED = -5
+    ERROR_INVALID_PARTNER_ID = -6
+    ERROR_INVALID_OBJECT_TYPE = -7
+    ERROR_RESULT_NOT_FOUND = -8
+    ERROR_READ_TIMEOUT = -9
+    ERROR_READ_GZIP_FAILED = -10
+
+    def __init__(self, message, code):
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return "%s (%s)" % (self.message, self.code)

--- a/sources/python/KalturaClient/exceptions.py
+++ b/sources/python/KalturaClient/exceptions.py
@@ -1,3 +1,4 @@
+
 # =============================================================================
 #                           _  __     _ _
 #                          | |/ /__ _| | |_ _  _ _ _ __ _
@@ -8,7 +9,7 @@
 # to do with audio, video, and animation what Wiki platfroms allow them to do
 # with text.
 #
-# Copyright (C) 2006-2017  Kaltura Inc.
+# Copyright (C) 2006-2018  Kaltura Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/ovp/python/KalturaClient/tests/test_accessControlProfile.py
+++ b/tests/ovp/python/KalturaClient/tests/test_accessControlProfile.py
@@ -19,53 +19,55 @@ class AccessControlProfileTests(KalturaBaseTest):
     def uniqid(self, prefix):
         return prefix + uuid.uuid1().hex
 
-    def test_profile(self):  
+    def test_profile(self):
         site = KalturaStringValue()
         site.value = "www.test.com"
-        
+
         condition1 = KalturaSiteCondition()
         condition1.not_ = True
         condition1.matchType = KalturaMatchConditionType.MATCH_ANY
         condition1.values = [site]
-        
+
         condition2 = KalturaSiteCondition()
         condition2.not_ = False
         condition2.matchType = KalturaMatchConditionType.MATCH_ANY
         condition2.values = [site]
-        
+
         rule = KalturaRule()
         rule.conditions = [condition1, condition2]
-    
+
         profile = KalturaAccessControlProfile()
         profile.name = self.uniqid('test_')
         profile.systemName = self.uniqid('test_')
         profile.description = self.uniqid('test ')
         profile.rules = [rule]
-        
+
         createdProfile = self.client.accessControlProfile.add(profile)
 
         self.assertIsInstance(createdProfile, KalturaAccessControlProfile)
         self.assertEqual(createdProfile.systemName, profile.systemName)
-        
+
         createdRule = createdProfile.rules[0]
         self.assertIsInstance(createdRule, KalturaRule)
-        
+
         createdCondition1 = createdRule.conditions[0]
         self.assertIsInstance(createdCondition1, KalturaSiteCondition)
         self.assertEqual(createdCondition1.not_, True)
-        
+
         createdCondition2 = createdRule.conditions[1]
         self.assertIsInstance(createdCondition2, KalturaSiteCondition)
         self.assertEqual(createdCondition2.not_, False)
-        
+
         self.client.accessControlProfile.delete(createdProfile.id)
-        
+
         return profile
+
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(AccessControlProfileTests)
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_distribution.py
+++ b/tests/ovp/python/KalturaClient/tests/test_distribution.py
@@ -4,50 +4,59 @@ import unittest
 
 from .utils import KalturaBaseTest
 
-from KalturaClient.Plugins.ContentDistribution import KalturaDistributionProviderListResponse, KalturaDistributionProvider
-from KalturaClient.Plugins.ContentDistribution import KalturaDistributionProfileListResponse, KalturaDistributionProfile
-from KalturaClient.Plugins.ContentDistribution import KalturaEntryDistributionListResponse, KalturaEntryDistribution
+from KalturaClient.Plugins.ContentDistribution import (
+    KalturaDistributionProfile,
+    KalturaDistributionProfileListResponse,
+    KalturaDistributionProvider,
+    KalturaDistributionProviderListResponse,
+    KalturaEntryDistribution,
+    KalturaEntryDistributionListResponse,
+    )
+
 
 class DistributionProviderTests(KalturaBaseTest):
-    
+
     def test_list(self):
         resp = self.client.contentDistribution.distributionProvider.list()
         self.assertIsInstance(resp, KalturaDistributionProviderListResponse)
-    
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-    
+
         [self.assertIsInstance(o, KalturaDistributionProvider) for o in objs]
-        
-        
+
+
 class DistributionProfileTests(KalturaBaseTest):
-    
+
     def test_list(self):
         resp = self.client.contentDistribution.distributionProfile.list()
-        self.assertIsInstance(resp, KalturaDistributionProfileListResponse)   
-        
+        self.assertIsInstance(resp, KalturaDistributionProfileListResponse)
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-    
+
         [self.assertIsInstance(o, KalturaDistributionProfile) for o in objs]
-        
-class entryDistributionTests(KalturaBaseTest):
-    
+
+
+class EntryDistributionTests(KalturaBaseTest):
+
     def test_list(self):
         resp = self.client.contentDistribution.entryDistribution.list()
         self.assertIsInstance(resp, KalturaEntryDistributionListResponse)
-    
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-    
+
         [self.assertIsInstance(o, KalturaEntryDistribution) for o in objs]
-    
+
+
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(DistributionProviderTests),
         unittest.makeSuite(DistributionProfileTests),
-        unittest.makeSuite(entryDistributionTests),
+        unittest.makeSuite(EntryDistributionTests),
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_flavorAsset.py
+++ b/tests/ovp/python/KalturaClient/tests/test_flavorAsset.py
@@ -6,25 +6,25 @@ from .utils import KalturaBaseTest
 
 from KalturaClient.Plugins.Core import KalturaFlavorAssetListResponse
 
+
 class FlavorAssetTests(KalturaBaseTest):
-     
+
     def test_instantiate(self):
         flavAsst = self.client.flavorAsset
-        
+
     def test_list(self):
         pass
-    
+
         #flavAsstList = flavAsst.list()
         ##TODO - Must set up a Filter and provide entryIdIn to properly test this.
         #self.assertIsInstance(flavAsstList, list)
-        
-        
-        
+
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(FlavorAssetTests),
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_functional.py
+++ b/tests/ovp/python/KalturaClient/tests/test_functional.py
@@ -1,12 +1,12 @@
-# ===================================================================================================
+# =============================================================================
 #                           _  __     _ _
 #                          | |/ /__ _| | |_ _  _ _ _ __ _
 #                          | ' </ _` | |  _| || | '_/ _` |
 #                          |_|\_\__,_|_|\__|\_,_|_| \__,_|
 #
 # This file is part of the Kaltura Collaborative Media Suite which allows users
-# to do with audio, video, and animation what Wiki platfroms allow them to do with
-# text.
+# to do with audio, video, and animation what Wiki platfroms allow them to do
+# with text.
 #
 # Copyright (C) 2006-2011  Kaltura Inc.
 #
@@ -24,15 +24,20 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 #
 # @ignore
-# ===================================================================================================
+# =============================================================================
 from __future__ import absolute_import, print_function
 
 import re
+import unittest
 
 import requests
 
-from .utils import (GetConfig, getTestFile, KalturaBaseTest)
-
+from .utils import (
+    GetConfig, getTestFile, KalturaBaseTest,
+    ADMIN_SECRET,
+    PARTNER_ID,
+    USER_NAME,
+)
 from KalturaClient import KalturaClient
 from KalturaClient.exceptions import KalturaException
 from KalturaClient.Plugins.Core import (
@@ -45,26 +50,35 @@ from KalturaClient.Plugins.Core import (
     KalturaMediaType,
     KalturaSessionType,
 )
+from KalturaClient.Plugins.Metadata import (
+    KalturaMetadataFilter,
+    KalturaMetadataObjectType,
+    KalturaMetadataProfile,
+    KalturaMetadataProfileFilter,
+)
+
 
 testString = "API Test ver %s" % (API_VERSION,)
 
 
 class SingleRequestTests(KalturaBaseTest):
-    """These Tests Are legacy tests migrated from the first test suite TestCode/PythonTester.py
-       into a unittest framework
+    """These Tests Are legacy tests migrated from the first test suite
+       TestCode/PythonTester.py into a unittest framework
        Great Examples to work from!
     """
-    
-    ### See Base Class 'setup' method for instantiating a client.
-    
+
+    # See Base Class 'setup' method for instantiating a client.
+
     def test_addmedia(self):
         ulFile = getTestFile('DemoVideo.flv')
         uploadTokenId = self.client.media.upload(ulFile)
 
         mediaEntry = KalturaMediaEntry()
-        mediaEntry.setName("Media Entry Using Python Client ver %s" % (API_VERSION,))
+        mediaEntry.setName(
+            "Media Entry Using Python Client ver %s" % (API_VERSION,))
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
 
         # serve
         DATA_ENTRY_CONTENT = 'bla bla bla'
@@ -75,23 +89,17 @@ class SingleRequestTests(KalturaBaseTest):
         serveUrl = self.client.data.serve(addedDataEntry.id)
         f = requests.get(serveUrl)
         assert(DATA_ENTRY_CONTENT == f.text)
-    
-    
+
     def test_SampleMetadataOperations(self):
-        
-        from KalturaClient.Plugins.Metadata import KalturaMetadataProfile
-        from KalturaClient.Plugins.Metadata import KalturaMetadataObjectType
-        from KalturaClient.Plugins.Metadata import KalturaMetadataProfileFilter
-        from KalturaClient.Plugins.Metadata import KalturaMetadataFilter        
-        
         # The metadata field we'll add/update
         metaDataFieldName = "SubtitleFormat"
         fieldValue = "VobSub"
-    
+
         # The Schema file for the field
-        # Currently, you must build the xsd yourself. There is no utility provided.
+        # Currently, you must build the xsd yourself. There is no utility
+        # provided.
         xsdFile = "MetadataSchema.xsd"
-    
+
         # Setup a pager and search to use
         pager = KalturaFilterPager()
         search = KalturaMediaEntryFilter()
@@ -99,201 +107,217 @@ class SingleRequestTests(KalturaBaseTest):
         search.setMediaTypeEqual(KalturaMediaType.VIDEO)  # Video only
         pager.setPageSize(10)
         pager.setPageIndex(1)
-    
+
         print("List videos, get the first one...")
-    
+
         # Get 10 video entries, but we'll just use the first one returned
         entries = self.client.media.list(search, pager).objects
-    
+
         # make sure we have a metadata profile
-        profile = KalturaMetadataProfile() 
+        profile = KalturaMetadataProfile()
         profile.setName('TestProfile %s' % (testString,))
         MetadataObjectType = KalturaMetadataObjectType.ENTRY
-        
+
         profile.setMetadataObjectType(MetadataObjectType)
         viewsData = ""
-    
+
         xsdFh = getTestFile(xsdFile)
-        newProfile = self.client.metadata.metadataProfile.add(profile, xsdFh.read(), viewsData)
-    
-        # Check if there are any custom fields defined in the KMC (Settings -> Custom Data)
+        newProfile = self.client.metadata.metadataProfile.add(
+            profile, xsdFh.read(), viewsData)
+
+        # Check if there are any custom fields defined in the KMC
+        # (Settings -> Custom Data)
         # for the first item returned by the previous listaction
         filter = KalturaMetadataProfileFilter()
-        metadata = self.client.metadata.metadataProfile.list(filter, pager).objects
-    
+        metadata = self.client.metadata.metadataProfile.list(
+            filter, pager).objects
+
         name = entries[0].getName()
         id = entries[0].getId()
-        if metadata[0].getXsd() != None:
+        if metadata[0].getXsd() is not None:
             print(
                 "1. There are custom fields for video: {}, entryid: {}".format(
                     name, id))
         else:
             print(
-                "1. There are no custom fields for video: {}, entryid: {}"\
-                .format(name, id))
-    
+                "1. There are no custom fields for video: {}, entryid: "
+                "{}" .format(name, id))
+
         # Add a custom data entry in the KMC  (Settings -> Custom Data)
         profile = KalturaMetadataProfile()
         profile.setName('TestProfile %s' % (testString,))
         profile.setMetadataObjectType(KalturaMetadataObjectType.ENTRY)
         viewsData = ""
-    
-        metadataResult = self.client.metadata.metadataProfile.update(newProfile.id, profile, xsdFh.read(), viewsData)
-    
-        assert(metadataResult.xsd != None)
-    
+
+        metadataResult = self.client.metadata.metadataProfile.update(
+            newProfile.id, profile, xsdFh.read(), viewsData)
+
+        self.assertIsNotNone(metadataResult.xsd)
+
         # Add the custom metadata value to the first video
         filter2 = KalturaMetadataFilter()
         filter2.setObjectIdEqual(entries[0].id)
-        xmlData = "<metadata><SubtitleFormat>" + fieldValue + "</SubtitleFormat></metadata>"
-        metadata2 = self.client.metadata.metadata.add(newProfile.id, profile.metadataObjectType, entries[0].id, xmlData)
-    
-        assert(metadata2.xml != None)
-        
-        print("3. Successfully added the custom data field for video: {}, entryid: {}".format(name, id))
+        xmlData = (
+            "<metadata><SubtitleFormat>{}"
+            "</SubtitleFormat></metadata>".format(fieldValue))
+        metadata2 = self.client.metadata.metadata.add(
+            newProfile.id, profile.metadataObjectType, entries[0].id, xmlData)
+
+        self.assertIsNotNone(metadata2.xml)
+
+        print(
+            "3. Successfully added the custom data field for video: {}, "
+            "entryid: {}".format(name, id))
         xmlStr = metadata2.xml
         print("XML used: %s" % xmlStr)
-    
+
         # Now lets change the value (update) of the custom field
         # Get the metadata for the video
         filter3 = KalturaMetadataFilter()
         filter3.setObjectIdEqual(entries[0].id)
         filter3.setMetadataProfileIdEqual(newProfile.id)
         metadataList = self.client.metadata.metadata.list(filter3).objects
-        assert(metadataList[0].xml != None)
-    
+        self.assertIsNotNone(metadataList[0].xml)
+
         print(
             "4. Current metadata for video: {}, entryid: {}".format(name, id))
         xmlquoted = metadataList[0].xml
         print("XML: {}".format(xmlquoted))
         xml = metadataList[0].xml
         # Make sure we find the old value in the current metadata
-        pos = xml.find("<" + metaDataFieldName + ">" + fieldValue + "</" + metaDataFieldName + ">")
+        pos = xml.find(
+            "<{metaDataFieldName}>{fieldValue}</{metaDataFieldName}>".format(
+                metaDataFieldName=metaDataFieldName, fieldValue=fieldValue))
         assert(pos >= 0)
-    
-        pattern = re.compile("<" + metaDataFieldName + ">([^<]+)</" + metaDataFieldName + ">")
-        xml = pattern.sub("<" + metaDataFieldName + ">Ogg Writ</" + metaDataFieldName + ">", xml)
+
+        pattern = re.compile(
+            "<{metaDataFieldName}>([^<]+)</{metaDataFieldName}>".format(
+                metaDataFieldName=metaDataFieldName))
+        xml = pattern.sub(
+            "<{metaDataFieldName}>Ogg Writ</{metaDataFieldName}>".format(
+                metaDataFieldName=metaDataFieldName),
+            xml)
         rc = self.client.metadata.metadata.update(metadataList[0].id, xml)
-        print("5. Updated metadata for video: {}, entryid: {}".format(name, id))
+        print(
+            "5. Updated metadata for video: {}, entryid: {}".format(name, id))
         xmlquoted = rc.xml
         print("XML: {}".format(xmlquoted))
 
 
-from .utils import PARTNER_ID, SERVICE_URL
-from .utils import ADMIN_SECRET, USER_NAME
-
 class MultiRequestTests(KalturaBaseTest):
-    
+
     def setUp(self):
         """These tests require that client.session.start be used
            Instead of self.client.generateSession
            TODO: Document Why
         """
-        
+
         self.config = GetConfig()
         self.client = KalturaClient(self.config)
         self.ks = None
-                  
-    
+
     def test_MultiRequest(self):
         """From lines 221- 241 of origional PythonTester.py"""
-        
+
         self.client.startMultiRequest()
-        ks = self.client.session.start(ADMIN_SECRET, USER_NAME, 
-                                       KalturaSessionType.ADMIN, 
-                                       PARTNER_ID, 86400, "") 
+        ks = self.client.session.start(ADMIN_SECRET, USER_NAME,
+                                       KalturaSessionType.ADMIN,
+                                       PARTNER_ID, 86400, "")
         self.client.setKs(ks)
-        
+
         listResult = self.client.baseEntry.list()
 
         multiResult = self.client.doMultiRequest()
         print(multiResult[1].totalCount)
         self.client.setKs(multiResult[0])
-        
+
         # error
-        try:
+        with self.assertRaises(KalturaException) as cm:
             mediaEntry = self.client.media.get('invalid entry id')
-            assert(False)
-        except KalturaException as e:
-            assert(e.code == 'ENTRY_ID_NOT_FOUND')                    
-           
+        assert(cm.exception.code == 'ENTRY_ID_NOT_FOUND')
+
         # multi request error
         self.client = KalturaClient(GetConfig())
 
-        #start a NEW multirequest (could move to separate unit test?)
+        # start a NEW multirequest (could move to separate unit test?)
         self.client.startMultiRequest()
 
-        ks = self.client.session.start(ADMIN_SECRET, USER_NAME, 
-                                            KalturaSessionType.ADMIN, 
-                                            PARTNER_ID, 86400, "")
+        ks = self.client.session.start(
+            ADMIN_SECRET, USER_NAME, KalturaSessionType.ADMIN, PARTNER_ID,
+            86400, "")
         self.client.setKs(ks)
 
         mediaEntry = self.client.media.get('invalid entry id')
-    
+
         multiResult = self.client.doMultiRequest()
         self.client.setKs(multiResult[0])
         assert(isinstance(multiResult[1], KalturaException))
-        assert(multiResult[1].code == 'ENTRY_ID_NOT_FOUND')    
+        assert(multiResult[1].code == 'ENTRY_ID_NOT_FOUND')
 
-        #must be called with existing client multirequest session
+        # must be called with existing client multirequest session
         self._AdvancedMultiRequestExample()
 
     # copied from C# tester
     def _AdvancedMultiRequestExample(self):
-        #this is a separate, local client - not 'self.client'
-        client = KalturaClient(self.config) #matches line 154 in PythonTester.py
+        # this is a separate, local client - not 'self.client'
+        client = KalturaClient(
+            self.config)  # matches line 154 in PythonTester.py
         client.startMultiRequest()
-        
+
         from KalturaClient.Plugins.Core import KalturaMixEntry
         from KalturaClient.Plugins.Core import KalturaEditorType
-        
+
         # Request 1
-        ks = client.session.start(ADMIN_SECRET, USER_NAME, 
-                                  KalturaSessionType.ADMIN, 
+        ks = client.session.start(ADMIN_SECRET, USER_NAME,
+                                  KalturaSessionType.ADMIN,
                                   PARTNER_ID, 86400, "")
-        client.setKs(ks) # for the current multi request, the result of the first call will be used as the ks for next calls
-  
+        # for the current multi request, the result of the first call will be
+        # used as the ks for next calls
+        client.setKs(ks)
+
         mixEntry = KalturaMixEntry()
         mixEntry.setName(".Net Mix %s" % (testString,))
         mixEntry.setEditorType(KalturaEditorType.SIMPLE)
-    
+
         # Request 2
         mixEntry = client.mixing.add(mixEntry)
-    
+
         # Request 3
         ulFile = getTestFile('DemoVideo.flv')
         uploadTokenId = client.media.upload(ulFile)
-    
+
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName("Media Entry For Mix %s" % (testString,))
         mediaEntry.setMediaType(KalturaMediaType.VIDEO)
-    
+
         # Request 4
-        mediaEntry = client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
-    
+        mediaEntry = client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
+
         # Request 5
         client.mixing.appendMediaEntry(mixEntry.id, mediaEntry.id)
-    
+
         response = client.doMultiRequest()
-    
+
         for subResponse in response:
             if isinstance(subResponse, KalturaException):
                 self.fail("Error occurred: " + subResponse.message)
-    
-        # when accessing the response object we will use an index and not the response number (response number - 1)
+
+        # when accessing the response object we will use an index and not the
+        # response number (response number - 1)
         assert(isinstance(response[1], KalturaMixEntry))
         mixEntry = response[1]
-        
+
         print("The new mix entry id is: {}".format(mixEntry.id))
 
 
-import unittest
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(SingleRequestTests),
         unittest.makeSuite(MultiRequestTests),
     ))
-        
+
+
 if __name__ == "__main__":
     suite = test_suite()
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/ovp/python/KalturaClient/tests/test_functional.py
+++ b/tests/ovp/python/KalturaClient/tests/test_functional.py
@@ -34,10 +34,10 @@ import requests
 from .utils import (GetConfig, getTestFile, KalturaBaseTest)
 
 from KalturaClient import KalturaClient
+from KalturaClient.exceptions import KalturaException
 from KalturaClient.Plugins.Core import (
     API_VERSION,
     KalturaDataEntry,
-    KalturaException,
     KalturaFilterPager,
     KalturaMediaEntry,
     KalturaMediaEntryFilter,

--- a/tests/ovp/python/KalturaClient/tests/test_media.py
+++ b/tests/ovp/python/KalturaClient/tests/test_media.py
@@ -4,58 +4,60 @@ import unittest
 
 import six
 
-from .utils import KalturaBaseTest
-from .utils import getTestFile
+from .utils import (getTestFile, KalturaBaseTest)
 
-from KalturaClient.Plugins.Core import KalturaMediaListResponse
-from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
+from KalturaClient.Plugins.Core import (
+    KalturaMediaEntry, KalturaMediaListResponse, KalturaMediaType)
 
 
 class MediaTests(KalturaBaseTest):
-    
+
     def test_list(self):
         resp = self.client.media.list()
         self.assertIsInstance(resp, KalturaMediaListResponse)
-        
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-        
+
         [self.assertIsInstance(o, KalturaMediaEntry) for o in objs]
-        
 
     def test_createRemote(self):
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName('pytest.MediaTests.test_createRemote')
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
-            
+
         ulFile = getTestFile('DemoVideo.flv')
-        uploadTokenId = self.client.media.upload(ulFile)            
-                     
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
-        
+        uploadTokenId = self.client.media.upload(ulFile)
+
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
+
         self.assertIsInstance(mediaEntry.getId(), six.text_type)
-        
-        #cleanup
+
+        # cleanup
         self.client.media.delete(mediaEntry.id)
-        
+
+
 class Utf8_tests(KalturaBaseTest):
-    
+
     def test_utf8_name(self):
-        test_unicode = six.u('\u03dd\xf5\xf6')  #an odd representation of the word 'FOO'
+        # an odd representation of the word 'FOO'
+        test_unicode = six.u('\u03dd\xf5\xf6')
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName(u'pytest.MediaTests.test_UTF8_name'+test_unicode)
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         ulFile = getTestFile('DemoVideo.flv')
         uploadTokenId = self.client.media.upload(ulFile)
-        
-        #this will throw an exception if fail.
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
-            
-        self.addCleanup(self.client.media.delete, mediaEntry.getId())
-    
-    def test_utf8_tags(self):
 
-        test_unicode = u'\u03dd\xf5\xf6'  #an odd representation of the word 'FOO'
+        # this will throw an exception if fail.
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
+
+        self.addCleanup(self.client.media.delete, mediaEntry.getId())
+
+    def test_utf8_tags(self):
+        # an odd representation of the word 'FOO'
+        test_unicode = u'\u03dd\xf5\xf6'
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName('pytest.MediaTests.test_UTF8_tags')
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
@@ -63,18 +65,20 @@ class Utf8_tests(KalturaBaseTest):
         uploadTokenId = self.client.media.upload(ulFile)
 
         mediaEntry.setTags(test_unicode)
-        
-        #this will throw an exception if fail.
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
-            
+
+        # this will throw an exception if fail.
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
+
         self.addCleanup(self.client.media.delete, mediaEntry.getId())
-        
+
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(MediaTests),
         unittest.makeSuite(Utf8_tests)
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_playlist.py
+++ b/tests/ovp/python/KalturaClient/tests/test_playlist.py
@@ -6,6 +6,7 @@ import six
 
 from .utils import getTestFile, KalturaBaseTest
 
+from KalturaClient.exceptions import KalturaException
 from KalturaClient.Plugins.Core import (
     KalturaPlaylist, KalturaPlaylistType, KalturaPlaylistListResponse)
 
@@ -145,8 +146,6 @@ class PlaylistTests(KalturaBaseTest):
         
         
     def test_updateExceptionReferenceIdNotSet(self):
-        from KalturaClient.Base import KalturaException
-        
         kplaylist = KalturaPlaylist()
         kplaylist.setName('pytest.PlaylistTests.test_updateExceptionReferenceIdNotSet')
         kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))

--- a/tests/ovp/python/KalturaClient/tests/test_playlist.py
+++ b/tests/ovp/python/KalturaClient/tests/test_playlist.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import time
+import unittest
 
 import six
 
@@ -8,182 +9,191 @@ from .utils import getTestFile, KalturaBaseTest
 
 from KalturaClient.exceptions import KalturaException
 from KalturaClient.Plugins.Core import (
-    KalturaPlaylist, KalturaPlaylistType, KalturaPlaylistListResponse)
+    KalturaCategory,
+    KalturaMediaEntry, KalturaMediaType,
+    KalturaPlaylist,
+    KalturaPlaylistFilter,
+    KalturaPlaylistListResponse,
+    KalturaPlaylistType)
 
 
 class PlaylistTests(KalturaBaseTest):
-     
+
     def test_instantiate(self):
         playlist = self.client.playlist
-        
+
     def test_list(self):
         resp = self.client.playlist.list()
-    
+
         self.assertIsInstance(resp, KalturaPlaylistListResponse)
-                
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-        
-        [self.assertIsInstance(o, KalturaPlaylist) for o in objs] 
-        
+
+        [self.assertIsInstance(o, KalturaPlaylist) for o in objs]
+
     def test_createRemote(self):
         kplaylist = KalturaPlaylist()
         kplaylist.setName('pytest.PlaylistTests.test_createRemote')
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST)) #??? STATIC LIST ???
-        
-        kplaylist = self.client.playlist.add(kplaylist)        
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(
+                KalturaPlaylistType.STATIC_LIST))  # ??? STATIC LIST ???
+
+        kplaylist = self.client.playlist.add(kplaylist)
         self.assertIsInstance(kplaylist, KalturaPlaylist)
-        
+
         self.assertIsInstance(kplaylist.getId(), six.text_type)
-        
-        #cleanup
+
+        # cleanup
         self.client.playlist.delete(kplaylist.getId())
-        
+
     #def test_listEntries(self):
     #    playlistId = '1_qv2ed7vm'
     #    kplaylist = self.client.playlist.get(playlistId)
     #    assertIsInstance(kplaylist.playlistContent, six.text_type)
     #    assertIsInstance(kplaylist.playlistContent.split(','), list)
-        
-        
-        
+
     def test_update(self):
         referenceId = 'pytest.PlaylistTests.test_update'
-        
+
         kplaylist = KalturaPlaylist()
         kplaylist.setName(referenceId)
         kplaylist.setReferenceId(referenceId)
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
-        kplaylist = self.client.playlist.add(kplaylist)        
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
+        kplaylist = self.client.playlist.add(kplaylist)
         self.addCleanup(self.client.playlist.delete, kplaylist.getId())
 
-        newPlaylist = KalturaPlaylist()        
+        newPlaylist = KalturaPlaylist()
         newPlaylist.setReferenceId(referenceId)
         newPlaylist.setName("changed!")
         self.client.playlist.update(kplaylist.getId(), newPlaylist)
-        
+
         resultPlaylist = self.client.playlist.get(kplaylist.getId())
         self.assertEqual("changed!", resultPlaylist.getName())
-        
-    def test_updateStaticContent(self):        
-                
-        from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
-        
+
+    def test_updateStaticContent(self):
         mediaEntry1 = KalturaMediaEntry()
         mediaEntry1.setName('pytest.PlaylistTests.test_updateStaticContent1')
         mediaEntry1.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         ulFile = getTestFile('DemoVideo.flv')
-        uploadTokenId = self.client.media.upload(ulFile) 
-        mediaEntry1 = self.client.media.addFromUploadedFile(mediaEntry1, uploadTokenId)
-        
+        uploadTokenId = self.client.media.upload(ulFile)
+        mediaEntry1 = self.client.media.addFromUploadedFile(
+            mediaEntry1, uploadTokenId)
+
         self.addCleanup(self.client.media.delete, mediaEntry1.getId())
-                
+
         mediaEntry2 = KalturaMediaEntry()
         mediaEntry2.setName('pytest.PlaylistTests.test_updateStaticContent2')
         mediaEntry2.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         ulFile = getTestFile('DemoVideo.flv')
-        uploadTokenId = self.client.media.upload(ulFile) 
-        mediaEntry2 = self.client.media.addFromUploadedFile(mediaEntry2, uploadTokenId)        
-        
+        uploadTokenId = self.client.media.upload(ulFile)
+        mediaEntry2 = self.client.media.addFromUploadedFile(
+            mediaEntry2, uploadTokenId)
+
         self.addCleanup(self.client.media.delete, mediaEntry2.getId())
-        
-        #playlistContent is simply a comma separated string of id's ?  
+
+        # playlistContent is simply a comma separated string of id's ?
         playlistContent = u','.join([mediaEntry1.getId(), mediaEntry2.getId()])
-                        
+
         kplaylist = KalturaPlaylist()
         kplaylist.setName('pytest.PlaylistTests.test_updateStaticContent')
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
-        
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
+
         kplaylist.setPlaylistContent(playlistContent)
         kplaylist = self.client.playlist.add(kplaylist)
-        
+
         self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
-        #fetch the playlist from server and test it's content.
+
+        # fetch the playlist from server and test it's content.
         resultPlaylist = self.client.playlist.get(kplaylist.getId())
         self.assertEqual(resultPlaylist.playlistContent, playlistContent)
-        
-        #import pdb; pdb.set_trace()  #go check your server
-        
-        
+
+        # import pdb; pdb.set_trace()  #go check your server
+
     def test_addStaticToExistingEmpty(self):
-        from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
         referenceId = 'pytest.PlaylistTests.test_addStaticToExistingEmpty'
-        #create empty playlist on server
+        # create empty playlist on server
         kplaylist = KalturaPlaylist()
         kplaylist.setName(referenceId)
         kplaylist.setReferenceId(referenceId)
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
         kplaylist = self.client.playlist.add(kplaylist)
         self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         playlistId = kplaylist.getId()
-        
-        #now, add some media
-        
+
+        # now, add some media
+
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName(referenceId)
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         ulFile = getTestFile('DemoVideo.flv')
-        uploadTokenId = self.client.media.upload(ulFile) 
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)         
+        uploadTokenId = self.client.media.upload(ulFile)
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
         self.addCleanup(self.client.media.delete, mediaEntry.getId())
-        
-        #add to (update) existing playlist
+
+        # add to (update) existing playlist
         newplaylist = KalturaPlaylist()
         newplaylist.setReferenceId(referenceId)
-    
+
         playlistContent = u','.join([mediaEntry.getId()])
         newplaylist.setPlaylistContent(playlistContent)
-        
+
         self.client.playlist.update(playlistId, newplaylist)
-        
-        #check it.
+
+        # check it.
         resultPlaylist = self.client.playlist.get(playlistId)
-        
+
         self.assertEqual(playlistContent, resultPlaylist.getPlaylistContent())
-        
-        
-        
+
     def test_updateExceptionReferenceIdNotSet(self):
         kplaylist = KalturaPlaylist()
-        kplaylist.setName('pytest.PlaylistTests.test_updateExceptionReferenceIdNotSet')
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
+        kplaylist.setName(
+            'pytest.PlaylistTests.test_updateExceptionReferenceIdNotSet')
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.STATIC_LIST))
         kplaylist = self.client.playlist.add(kplaylist)
         self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         playlistId = kplaylist.getId()
-        
+
         playlist = self.client.playlist.get(playlistId)
-        
-        #don't set referenceId
-        
-        self.assertRaises(KalturaException, self.client.playlist.update, playlistId, playlist) 
-    
+
+        # don't set referenceId
+
+        self.assertRaises(
+            KalturaException, self.client.playlist.update, playlistId,
+            playlist)
+
+
 class DynamicPlaylistTests(KalturaBaseTest):
-    
+
     def test_createRemote(self):
         kplaylist = KalturaPlaylist()
         kplaylist.setName('pytest.PlaylistTests.test_createRemote')
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
-        
-        #must add a totalResults field
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
+
+        # must add a totalResults field
         kplaylist.setTotalResults(10)
-        
-        kplaylist = self.client.playlist.add(kplaylist)        
+
+        kplaylist = self.client.playlist.add(kplaylist)
         self.assertIsInstance(kplaylist, KalturaPlaylist)
-        
+
         self.assertIsInstance(kplaylist.getId(), six.text_type)
-        
-        #cleanup
-        self.client.playlist.delete(kplaylist.getId())        
-        
+
+        # cleanup
+        self.client.playlist.delete(kplaylist.getId())
+
     #def test_createTagRule(self):
-        #from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
         #from KalturaClient.Plugins.Core import KalturaMediaEntryFilterForPlaylist
-        
+
         #referenceId = 'pytest.DynamicPlaylistTests.test_createTagRule'
-        
+
         ##create a video, and put a tag on it.
         #mediaEntry = KalturaMediaEntry()
         #mediaEntry.setName(referenceId)
@@ -191,28 +201,28 @@ class DynamicPlaylistTests(KalturaBaseTest):
         #mediaEntry.setTags('footag')
         #mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         #ulFile = getTestFile('DemoVideo.flv')
-        #uploadTokenId = self.client.media.upload(ulFile) 
+        #uploadTokenId = self.client.media.upload(ulFile)
         #mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
         #self.addCleanup(self.client.media.delete, mediaEntry.getId())
-        
+
         ##create a playlist
         #kplaylist = KalturaPlaylist()
         #kplaylist.setName(referenceId)
         #kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
         #kplaylist.setTotalResults(10)
         #kplaylist.setReferenceId(referenceId)
-        
+
         ##create a filter for the playlist
         #playlistFilter = KalturaMediaEntryFilterForPlaylist()
         #playlistFilter.setTagsMultiLikeOr('footag')
 
         #filtersArray = [playlistFilter,]
-        
+
         #kplaylist.setFilters(filtersArray)
 
         #kplaylist = self.client.playlist.add(kplaylist)
         #self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         #print "Waiting for Media Entry to be 'Ready'"
         #sleeptime=5
         #mediaEntry = self.client.media.get(mediaEntry.getId())
@@ -220,19 +230,18 @@ class DynamicPlaylistTests(KalturaBaseTest):
             #print "media entry status is %s " % (mediaEntry.getStatus().getValue())
             #time.sleep(sleeptime)
             #mediaEntry = self.client.media.get(mediaEntry.getId())
-        
+
         #results = self.client.playlist.execute(kplaylist.getId(), kplaylist)
-        
+
         #self.assertEqual(len(results), 1)
         #self.assertEqual(results[0].getName(), referenceId)
-        
+
     #def test_createSingleCategoryRule(self):
-        #from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
         #from KalturaClient.Plugins.Core import KalturaPlaylistFilter
         #referenceId = 'pytest.DynamicPlaylistTests.test_createSingleCategoryRule'
-                
-        #categories = "category1"        
-                
+
+        #categories = "category1"
+
         ##create a video, and assign it to a category.
         #mediaEntry = KalturaMediaEntry()
         #mediaEntry.setName(referenceId)
@@ -240,25 +249,25 @@ class DynamicPlaylistTests(KalturaBaseTest):
         #mediaEntry.setCategories(categories)
         #mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         #ulFile = getTestFile('DemoVideo.flv')
-        #uploadTokenId = self.client.media.upload(ulFile) 
-        #mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)         
-        #self.addCleanup(self.client.media.delete, mediaEntry.getId())    
-        
+        #uploadTokenId = self.client.media.upload(ulFile)
+        #mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
+        #self.addCleanup(self.client.media.delete, mediaEntry.getId())
+
         ##create a playlist
         #kplaylist = KalturaPlaylist()
         #kplaylist.setName(referenceId)
         #kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
         #kplaylist.setTotalResults(10)
         #kplaylist.setReferenceId(referenceId)
-        
+
         ##Create A Filter
         #kFilter = KalturaPlaylistFilter()
         #kFilter.setCategoriesFullNameIn(categories)
         #kplaylist.setFilters([kFilter])
-        
+
         #kplaylist = self.client.playlist.add(kplaylist)
         #self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         #print "Waiting for Media Entry to be 'Ready'"
         #sleeptime=5
         #mediaEntry = self.client.media.get(mediaEntry.getId())
@@ -266,96 +275,92 @@ class DynamicPlaylistTests(KalturaBaseTest):
             #print "media entry status is %s " % (mediaEntry.getStatus().getValue())
             #time.sleep(sleeptime)
             #mediaEntry = self.client.media.get(mediaEntry.getId())
-        
+
         #results = self.client.playlist.execute(kplaylist.getId(), kplaylist)
-        
+
         #self.assertEqual(len(results), 1)
         #self.assertEqual(results[0].getName(), referenceId)
 
     def test_createAncestorCategoryRule(self):
-        from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
-        from KalturaClient.Plugins.Core import KalturaPlaylistFilter
-        from KalturaClient.Plugins.Core import KalturaCategory
-        
-        referenceId = 'pytest.DynamicPlaylistTests.test_createAncestorCategoryRule'
-                
-        #create category entry hierarchy
+        referenceId = (
+            'pytest.DynamicPlaylistTests.test_createAncestorCategoryRule')
+
+        # create category entry hierarchy
         topCategory = KalturaCategory()
         topCategory.setName('TopCategory_' + str(time.time()))
         topCategory = self.client.category.add(topCategory)
         self.addCleanup(self.client.category.delete, topCategory.getId())
-        
+
         subCategory = KalturaCategory()
         subCategory.setName("SubCategory" + str(time.time()))
         subCategory.setParentId(topCategory.getId())
         subCategory = self.client.category.add(subCategory)
         self.addCleanup(self.client.category.delete, subCategory.getId())
-                
-        #create a video, and assign it to subCategory.
+
+        # create a video, and assign it to subCategory.
         mediaEntry = KalturaMediaEntry()
         mediaEntry.setName(referenceId)
         mediaEntry.setReferenceId(referenceId)
         mediaEntry.setCategoriesIds(subCategory.getId())
         mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         ulFile = getTestFile('DemoVideo.flv')
-        uploadTokenId = self.client.media.upload(ulFile) 
-        mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)         
-        self.addCleanup(self.client.media.delete, mediaEntry.getId())    
-        
-        #create a playlist
+        uploadTokenId = self.client.media.upload(ulFile)
+        mediaEntry = self.client.media.addFromUploadedFile(
+            mediaEntry, uploadTokenId)
+        self.addCleanup(self.client.media.delete, mediaEntry.getId())
+
+        # create a playlist
         kplaylist = KalturaPlaylist()
         kplaylist.setName(referenceId)
-        kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
+        kplaylist.setPlaylistType(
+            KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
         kplaylist.setTotalResults(10)
         kplaylist.setReferenceId(referenceId)
-        
-        #Create A Filter - use Top Level Category
+
+        # Create A Filter - use Top Level Category
         kFilter = KalturaPlaylistFilter()
         kFilter.setCategoryAncestorIdIn(topCategory.getId())
         kplaylist.setFilters([kFilter])
-        
+
         kplaylist = self.client.playlist.add(kplaylist)
         self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         print("Waiting for Media Entry to be 'Ready'")
-        sleeptime=5
+        sleeptime = 5
         mediaEntry = self.client.media.get(mediaEntry.getId())
         while mediaEntry.getStatus().getValue() != '2':
-            print("media entry status is {}".format(mediaEntry.getStatus().getValue()))
+            print(
+                "media entry status is {}".format(
+                    mediaEntry.getStatus().getValue()))
             time.sleep(sleeptime)
             mediaEntry = self.client.media.get(mediaEntry.getId())
-        
+
         results = self.client.playlist.execute(kplaylist.getId(), kplaylist)
-        
+
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].getName(), referenceId)
-        
+
     #def test_EditAncestorCategoryRule(self):
-        
-        #from KalturaClient.Plugins.Core import KalturaMediaEntry, KalturaMediaType
-        #from KalturaClient.Plugins.Core import KalturaPlaylistFilter
-        #from KalturaClient.Plugins.Core import KalturaCategory
-        
         #referenceId = 'pytest.DynamicPlaylistTests.test_EditAncestorCategoryRule'
-                
+
         ##create category entry hierarchy
         #topCategory = KalturaCategory()
         #topCategory.setName("TopCategory")
         #topCategory = self.client.category.add(topCategory)
         #self.addCleanup(self.client.category.delete, topCategory.getId())
-        
+
         #subCategory = KalturaCategory()
         #subCategory.setName("SubCategory")
         #subCategory.setParentId(topCategory.getId())
         #subCategory = self.client.category.add(subCategory)
         #self.addCleanup(self.client.category.delete, subCategory.getId())
-        
+
         #subCategory2 = KalturaCategory()
         #subCategory2.setName("SubCategory2")
         #subCategory2.setParentId(topCategory.getId())
         #subCategory2 = self.client.category.add(subCategory2)
-        #self.addCleanup(self.client.category.delete, subCategory2.getId())        
-                
+        #self.addCleanup(self.client.category.delete, subCategory2.getId())
+
         ##create a video, and assign it to subCategory.
         #mediaEntry = KalturaMediaEntry()
         #mediaEntry.setName(referenceId)
@@ -363,10 +368,10 @@ class DynamicPlaylistTests(KalturaBaseTest):
         #mediaEntry.setCategoriesIds(subCategory.getId())
         #mediaEntry.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         #ulFile = getTestFile('DemoVideo.flv')
-        #uploadTokenId = self.client.media.upload(ulFile) 
-        #mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)         
+        #uploadTokenId = self.client.media.upload(ulFile)
+        #mediaEntry = self.client.media.addFromUploadedFile(mediaEntry, uploadTokenId)
         #self.addCleanup(self.client.media.delete, mediaEntry.getId())
-        
+
         ##create another, assign it to subCategory2
         #mediaEntry2 = KalturaMediaEntry()
         #mediaEntry2.setName(referenceId+"2")
@@ -374,43 +379,43 @@ class DynamicPlaylistTests(KalturaBaseTest):
         #mediaEntry2.setCategoriesIds(subCategory2.getId())
         #mediaEntry2.setMediaType(KalturaMediaType(KalturaMediaType.VIDEO))
         #ulFile = getTestFile('DemoVideo.flv')
-        #uploadTokenId = self.client.media.upload(ulFile) 
-        #mediaEntry2 = self.client.media.addFromUploadedFile(mediaEntry2, uploadTokenId)         
+        #uploadTokenId = self.client.media.upload(ulFile)
+        #mediaEntry2 = self.client.media.addFromUploadedFile(mediaEntry2, uploadTokenId)
         #self.addCleanup(self.client.media.delete, mediaEntry2.getId())
-        
-        
+
+
         ##create a playlist
         #kplaylist = KalturaPlaylist()
         #kplaylist.setName(referenceId)
         #kplaylist.setPlaylistType(KalturaPlaylistType(KalturaPlaylistType.DYNAMIC))
         #kplaylist.setTotalResults(10)
         #kplaylist.setReferenceId(referenceId)
-        
+
         ##Create A Filter - use Top Level Category
         #kFilter = KalturaPlaylistFilter()
         #kFilter.setCategoryAncestorIdIn(topCategory.getId())
         #kplaylist.setFilters([kFilter])
-        
+
         #kplaylist = self.client.playlist.add(kplaylist)
         #self.addCleanup(self.client.playlist.delete, kplaylist.getId())
-        
+
         #print "Waiting for Media Entry to be 'Ready'"
         #sleeptime=5
-        #mediaEntry, mediaEntry2 = (self.client.media.get(mediaEntry.getId()), 
+        #mediaEntry, mediaEntry2 = (self.client.media.get(mediaEntry.getId()),
                                    #self.client.media.get(mediaEntry2.getId()))
         #while mediaEntry.getStatus().getValue() != '2' \
               #and mediaEntry2.getStatus().getValue() != '2':
             #print "media entry status is %s, %s " % (mediaEntry.getStatus().getValue(),
                                                      #mediaEntry2.getStatus().getValue() )
             #time.sleep(sleeptime)
-            #mediaEntry, mediaEntry2 = (self.client.media.get(mediaEntry.getId()), 
+            #mediaEntry, mediaEntry2 = (self.client.media.get(mediaEntry.getId()),
                                    #self.client.media.get(mediaEntry2.getId()))
-            
+
         #results = self.client.playlist.execute(kplaylist.getId(), kplaylist)
-        
+
         ##test existing Rule
         #self.assertEqual(len(results), 2)
-        
+
         ##import pdb; pdb.set_trace()
         ####Edit filter to only search for SubCategory2 now.
         #new_kFilter = KalturaPlaylistFilter()
@@ -419,21 +424,20 @@ class DynamicPlaylistTests(KalturaBaseTest):
         #new_kplaylist.setReferenceId(referenceId)
         #new_kplaylist.setFilters([new_kFilter])
         #result_kplaylist = self.client.playlist.update(kplaylist.getId(), new_kplaylist)
-        
+
         ##import pdb; pdb.set_trace()
         #results = self.client.playlist.execute(result_kplaylist.getId(), kplaylist)
-        
+
         #self.assertEqual(len(results), 1)
         #self.assertEqual(results[0].getName(), referenceId+'2')
-        
-        
-        
-import unittest
+
+
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(PlaylistTests),
         unittest.makeSuite(DynamicPlaylistTests),
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_uiconf.py
+++ b/tests/ovp/python/KalturaClient/tests/test_uiconf.py
@@ -14,35 +14,36 @@ from KalturaClient.Plugins.Core import (
 
 
 class UiConfTests(KalturaBaseTest):
-     
+
     def test_list(self):
         resp = self.client.uiConf.list()
         self.assertIsInstance(resp, KalturaUiConfListResponse)
-        
+
         objs = resp.objects
         self.assertIsInstance(objs, list)
-        
+
         for o in objs:
             self.assertIsInstance(o, KalturaUiConf)
-        
+
     def test_get_players(self):
         filt = KalturaUiConfFilter()
-        
+
         players = [
                    KalturaUiConfObjType.PLAYER_V3,
                    KalturaUiConfObjType.PLAYER,
                    KalturaUiConfObjType.PLAYER_SL,
                   ]
         filt.setObjTypeIn(players)
-       
+
         resp = self.client.uiConf.list(filter=filt)
         objs = resp.objects
-        
+
         for o in objs:
             self.assertIn(o.objType.getValue(), players)
-        
+
     '''def test_get_playlist_players(self):
-        """Until I find a better way... this gets all uiconfs that are 'playlist players'
+        """Until I find a better way... this gets all uiconfs that are
+           'playlist players'
            not sure if this is the right way"""
         filt = KalturaUiConfFilter()
         players = [
@@ -51,23 +52,24 @@ class UiConfTests(KalturaBaseTest):
                    KalturaUiConfObjType.PLAYER_SL,
                   ]
         tags = 'playlist'
-        
+
         filt.setObjTypeIn(players)
         filt.setTagsMultiLikeOr(tags)
-       
+
         resp = self.client.uiConf.list(filter=filt)
         objs = resp.objects
-        
+
         for o in objs:
             self.assertIn(o.objType.getValue(), players)
             match = re.search('isPlaylist="(.*?)"', o.getConfFile())
             self.assertIsNotNone(match, "isPlaylist not found in confFile")
-            
+
             value = match.group(1)
             self.assertIn(value, ["true", "multi"])'''
-            
+
     def test_get_video_players(self):
-        """Until I find a better way... this gets all uiconfs that are 'single video' players
+        """Until I find a better way... this gets all uiconfs that are
+           'single video' players
            Not sure if this is the right way"""
         filt = KalturaUiConfFilter()
         players = [KalturaUiConfObjType.PLAYER_V3,
@@ -75,13 +77,13 @@ class UiConfTests(KalturaBaseTest):
                    KalturaUiConfObjType.PLAYER_SL,
                   ]
         tags = 'player'
-        
+
         filt.setObjTypeIn(players)
         filt.setTagsMultiLikeOr(tags)
-       
+
         resp = self.client.uiConf.list(filter=filt)
         objs = resp.objects
-        
+
         for o in objs:
             self.assertIn(o.objType.getValue(), players)
             match = re.search('isPlaylist="(.*?)"', o.getConfFile())
@@ -90,26 +92,23 @@ class UiConfTests(KalturaBaseTest):
             else:
                 value = match.group(1)
                 self.assertIn(value, ["true", "multi"])
-                
-            
+
     def test_list_templates(self):
         templates = self.client.uiConf.listTemplates()
         self.assertIsInstance(templates, KalturaUiConfListResponse)
-        
+
         objs = templates.objects
         self.assertIsInstance(objs, list)
-        
+
         for o in objs:
             self.assertIsInstance(o, KalturaUiConf)
-        
-        
-        
-        
-        
+
+
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(UiConfTests),
         ))
+
 
 if __name__ == "__main__":
     suite = test_suite()

--- a/tests/ovp/python/KalturaClient/tests/test_widget.py
+++ b/tests/ovp/python/KalturaClient/tests/test_widget.py
@@ -6,8 +6,9 @@ from .utils import KalturaBaseTest
 
 from KalturaClient.Plugins.Core import KalturaWidgetListResponse
 
+
 class WidgetTests(KalturaBaseTest):
-     
+
     def test_list_widgets(self):
         widgets = self.client.widget.list()
         self.assertIsInstance(widgets, KalturaWidgetListResponse)
@@ -18,8 +19,7 @@ def test_suite():
         unittest.makeSuite(WidgetTests),
         ))
 
+
 if __name__ == "__main__":
     suite = test_suite()
     unittest.TextTestRunner(verbosity=2).run(suite)
-    
-    


### PR DESCRIPTION
Various Python cleanups to start bringing the Python client up to current standards, and more in line with the other clients (such as the Ruby client, which is far simpler).

* Bring the code (mostly) in line with PEP8 - camel casing is left alone for now, as it would break the API too much.
* Get rid of wildcard imports - bad practice, and makes static analysis possible (e.g. identifying unused or missing imports)
* Replace xml.dom with xml.etree - this is cleaner, as we avoid rolling our own XPath implementation. (For performance, in future we can make lxml an optional dependency with xml.etree as the fallback).
* Remove KalturaFiles - use a plain dict, this object is not adding anything.