### PR TITLE
PLAT-9423: Aviod exception when no description found on param

### DIFF
--- a/sources/testme/js/kField.js
+++ b/sources/testme/js/kField.js
@@ -52,7 +52,7 @@ kField.prototype = {
 		
 		if(!this.jqHelp){
 			var helpText = this.param.name;
-			if(this.param.description.length)
+			if(this.param && this.param.description && this.param.description.length)
 				helpText += ' - ' + this.param.description;
 			
 			this.jqHelp = jQuery('<div><img src="images/help.png" class="help" title="' + helpText + '" /></div>');


### PR DESCRIPTION
When two fields with the same complex class type exist under the same object only the first will have the full JSON data other will have only the type. 
Prior to the change due to the error in accessing the description field, this.loadSubClasses() would have never be called.

https://github.com/kaltura/clients-generator/blob/Naos-14.8.0/lib/TestmeGenerator.php#L89
