### PR TITLE
Fix push to PyPI failure

### DIFF
--- a/sources/python/setup.py
+++ b/sources/python/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.txt')) as f:
+        long_description = f.read()
 
 setup(
     name='KalturaApiClient',
@@ -23,5 +27,6 @@ setup(
     ],
     keywords='Kaltura API client',
     description='A Python module for accessing the Kaltura API.',
-    long_description=open('README.txt').read(),
+    long_description=long_description,
+    long_description_content_type="text/plain"
 )


### PR DESCRIPTION
Current setup.py fails with: HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See
https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/