### PR TITLE
Change chunk upload chunk size to be at least 5MB and report minimum chunk size when creating the upload token

### DIFF
--- a/sources/ngx/projects/kaltura-ngx-client/CHANGELOG.md
+++ b/sources/ngx/projects/kaltura-ngx-client/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 11.4.0 (2019-06-24)
+
+### Features
+
+* Update minimum chunk size to the higher value between 5mb and {file size}/10,000 PLAT-9931 
+
 ## 11.3.0 (2019-04-11)
 
 ### Features

--- a/sources/ngx/projects/kaltura-ngx-client/package-lock.json
+++ b/sources/ngx/projects/kaltura-ngx-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaltura-ngx-client",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sources/ngx/projects/kaltura-ngx-client/package.json
+++ b/sources/ngx/projects/kaltura-ngx-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kaltura-ngx-client",
   "private": true,
-  "version": "11.3.0",
+  "version": "11.4.0",
   "description": "Kaltura Angular based client",
   "keywords": [
     "Kaltura"

--- a/sources/ngx/projects/kaltura-ngx-client/src/lib/adapters/kaltura-upload-request-adapter.ts
+++ b/sources/ngx/projects/kaltura-ngx-client/src/lib/adapters/kaltura-upload-request-adapter.ts
@@ -153,7 +153,7 @@ export class KalturaUploadRequestAdapter {
             console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 5Mb. using value 5Mb instead`);
             actualChunkFileSize = 5e6;
           } else {
-            console.log(`using user requetsed chunk size '${userChunkFileSize}'`);
+            console.log(`using user requested chunk size '${userChunkFileSize}'`);
             actualChunkFileSize = userChunkFileSize;
           }
         } else {
@@ -163,7 +163,7 @@ export class KalturaUploadRequestAdapter {
 
         if (file && file.size && file.size/1e4 > actualChunkFileSize) {
           actualChunkFileSize = file.size/1e4;
-          console.warn(`requested chunk size '${actualChunkFileSize}' is not optional as minimal value must be larger then {file size}/10,000. setting new chunk size '${actualChunkFileSize} for file with size ${file.size}`);
+          console.warn(`requested chunk size is not possible, minimal value must be larger then {file size}/10,000 (${file.size}/10,000). setting custom chunk size ${actualChunkFileSize} for this specific file upload`);
         }
 
         uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;

--- a/sources/ngx/projects/kaltura-ngx-client/src/lib/adapters/kaltura-upload-request-adapter.ts
+++ b/sources/ngx/projects/kaltura-ngx-client/src/lib/adapters/kaltura-upload-request-adapter.ts
@@ -149,9 +149,9 @@ export class KalturaUploadRequestAdapter {
         const userChunkFileSize = this.clientOptions ? this.clientOptions.chunkFileSize : null;
 
         if (userChunkFileSize && Number.isFinite(userChunkFileSize) && !Number.isNaN(userChunkFileSize)) {
-          if (userChunkFileSize < 1e5) {
-            console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 100Kb. using minimal value 100Kb instead`);
-            actualChunkFileSize = 1e5;
+          if (userChunkFileSize < 5e6) {
+            console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 5Mb. using value 5Mb instead`);
+            actualChunkFileSize = 5e6;
           } else {
             console.log(`using user requetsed chunk size '${userChunkFileSize}'`);
             actualChunkFileSize = userChunkFileSize;
@@ -159,6 +159,11 @@ export class KalturaUploadRequestAdapter {
         } else {
           console.log(`using default chunk size 5Mb`);
           actualChunkFileSize = 5e6; // default
+        }
+
+        if (file && file.size && file.size/1e4 > actualChunkFileSize) {
+          actualChunkFileSize = file.size/1e4;
+          console.warn(`requested chunk size '${actualChunkFileSize}' is not optional as minimal value must be larger then {file size}/10,000. setting new chunk size '${actualChunkFileSize} for file with size ${file.size}`);
         }
 
         uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;

--- a/sources/typescript/CHANGELOG.md
+++ b/sources/typescript/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 7.1.0 (2019-06-24)
+
+### Features
+
+* Update minimum chunk size to the higher value between 5mb and {file size}/10,000 PLAT-9931 
+
+
 ## 7.0.1 (2019-06-12)
 
 ### Fix
 
 * upload asset was not working due to bad url creation.
 
-## 7.0.0 (2019-01-24)
 
+## 7.0.0 (2019-01-24)
 
  ### Breaking Change
  

--- a/sources/typescript/package-lock.json
+++ b/sources/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaltura-typescript-client",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sources/typescript/package.json
+++ b/sources/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kaltura-typescript-client",
   "private": true,
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Kaltura Typescript client",
   "keywords": [
     "Kaltura"

--- a/sources/typescript/src/adapters/kaltura-upload-request-adapter.ts
+++ b/sources/typescript/src/adapters/kaltura-upload-request-adapter.ts
@@ -121,16 +121,21 @@ export class KalturaUploadRequestAdapter {
                 const userChunkFileSize = this.clientOptions ? this.clientOptions.chunkFileSize : null;
 
                 if (userChunkFileSize && Number.isFinite(userChunkFileSize) && !Number.isNaN(userChunkFileSize)) {
-	                if (userChunkFileSize < 1e5) {
-		                console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 100Kb. using minimal value 100Kb instead`);
-		                actualChunkFileSize = 1e5;
-	                } else {
+                    if (userChunkFileSize < 5e6) {
+                        console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 5Mb. using value 5Mb instead`);
+                        actualChunkFileSize = 5e6;
+                    } else {
                         console.log(`using user requetsed chunk size '${userChunkFileSize}'`);
                         actualChunkFileSize = userChunkFileSize;
                     }
                 } else {
                     console.log(`using default chunk size 5Mb`);
                     actualChunkFileSize = 5e6; // default
+                }
+
+                if (file && file.size && file.size/1e4 > actualChunkFileSize) {
+                    actualChunkFileSize = file.size/1e4;
+                    console.warn(`requested chunk size '${actualChunkFileSize}' is not optional as minimal value must be larger then {file size}/10,000. setting new chunk size '${actualChunkFileSize} for file with size ${file.size}`);
                 }
 
                 uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;

--- a/sources/typescript/src/adapters/kaltura-upload-request-adapter.ts
+++ b/sources/typescript/src/adapters/kaltura-upload-request-adapter.ts
@@ -125,7 +125,7 @@ export class KalturaUploadRequestAdapter {
                         console.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 5Mb. using value 5Mb instead`);
                         actualChunkFileSize = 5e6;
                     } else {
-                        console.log(`using user requetsed chunk size '${userChunkFileSize}'`);
+                        console.log(`using user requested chunk size '${userChunkFileSize}'`);
                         actualChunkFileSize = userChunkFileSize;
                     }
                 } else {
@@ -135,7 +135,7 @@ export class KalturaUploadRequestAdapter {
 
                 if (file && file.size && file.size/1e4 > actualChunkFileSize) {
                     actualChunkFileSize = file.size/1e4;
-                    console.warn(`requested chunk size '${actualChunkFileSize}' is not optional as minimal value must be larger then {file size}/10,000. setting new chunk size '${actualChunkFileSize} for file with size ${file.size}`);
+                    console.warn(`requested chunk size is not possible, minimal value must be larger then {file size}/10,000 (${file.size}/10,000). setting custom chunk size ${actualChunkFileSize} for this specific file upload`);
                 }
 
                 uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;


### PR DESCRIPTION
 I modified both typescript and ngx libraries. Angular library was tested with local kmc, Typescript library tested with local express recorder:

- upload without user configured chunk size default to 5mb
- upload with user configured chunk size lower then 5mb will fallback to 5mb
- upload with user configured chunk size bigger then 5mb is allowed
- upload minimum size is fixed automatically once user tries to upload file with size file/10000 > chunk size

