### PR TITLE
added response log length property to base request builder and client

### DIFF
--- a/sources/csharp2/KalturaClient/ClientBase.cs
+++ b/sources/csharp2/KalturaClient/ClientBase.cs
@@ -49,11 +49,9 @@ namespace Kaltura
         protected ClientConfiguration clientConfiguration = new ClientConfiguration();
         protected RequestConfiguration requestConfiguration = new RequestConfiguration();
         
-        public Configuration Configuration
-        {
-            get;
-            set;
-        }
+        public int? ResponseLogLength { get; set; }
+
+        public Configuration Configuration{ get; set; }
 
         public ClientConfiguration ClientConfiguration
         {

--- a/sources/csharp2/KalturaClient/Request/BaseRequestBuilder.cs
+++ b/sources/csharp2/KalturaClient/Request/BaseRequestBuilder.cs
@@ -23,11 +23,8 @@ namespace Kaltura.Request
         private Client client = null;
         private readonly string requestId;
 
-        public string Boundary
-        {
-            get;
-            set;
-        }
+        public int? ResponseLogLength { get; set; }
+        public string Boundary { get; set; }
 
         public BaseRequestBuilder(string service)
         {
@@ -161,7 +158,16 @@ namespace Kaltura.Request
                 {
                     var responseString = await responseReader.ReadToEndAsync();
                     var headersStr = GetResponseHeadersString(response);
-                    this.Log(string.Format("result : {0}", responseString));
+
+                    var responseLogMsg = responseString;
+                    var responseLogLengthToUse = this.ResponseLogLength.HasValue? this.ResponseLogLength : client.ResponseLogLength;
+                    if (responseLogLengthToUse.HasValue)
+                    {
+                        var trimLength = Math.Min(responseLogLengthToUse.Value, responseString.Length);
+                        responseLogMsg = responseString.Substring(0,trimLength);
+                    }
+
+                    this.Log(string.Format("result : {0}", responseLogMsg));
                     this.Log(string.Format("result headers : {0}", headersStr));
 
                     responseObject = ParseResponseString<T>(responseString);


### PR DESCRIPTION
This adding a new property to set on the Client "ResponseLogLength" which will trim the response to the specified length.

default is set to null which will print the entire response (backward compatibility) 

add same property to the BaseRequestBuilder to allow setting Response Log Length per specific request (Overriding the client definition)