### PR TITLE
feat(node2): add support for Buffer instead of filepaths

### DIFF
--- a/sources/node2/KalturaClientBase.js
+++ b/sources/node2/KalturaClientBase.js
@@ -274,9 +274,17 @@ class RequestBuilder extends kaltura.VolatileRequestData {
 					continue;
 				}
 
-				let filePath = files[key];
-				let fileName = path.basename(filePath);
-				let data = fs.readFileSync(filePath);
+				let fileName;
+				let data;
+				if (files[key] instanceof Buffer) {
+					fileName = 'chunk';
+					data = files[key];
+				} else {
+					let filePath = files[key];
+					fileName = path.basename(filePath);
+					data = fs.readFileSync(filePath);
+				}
+
 				let headers = ['Content-Disposition: form-data; name="' + key + '"; filename="' + fileName + '"' + crlf, 'Content-Type: application/octet-stream' + crlf];
 
 				postData.push(new Buffer(delimiter + crlf + headers.join('') + crlf));

--- a/tests/ovp/node2/test/media.js
+++ b/tests/ovp/node2/test/media.js
@@ -140,13 +140,8 @@ describe("Add media", () => {
 				.execute(client)
 				.then(token => {
 					createdUploadToken = token;
-					return kaltura.services.uploadToken.upload(
-						createdUploadToken.id,
-						Buffer.alloc(0),
-						false,
-						false,
-						0,
-					).execute(client);
+					return kaltura.services.uploadToken.upload(createdUploadToken.id, Buffer.alloc(0), false, false, 0)
+						.execute(client);
 				})
 				.then((uploadToken) => {
 					expect(uploadToken.status).to.equal(kaltura.enums.UploadTokenStatus.PARTIAL_UPLOAD);
@@ -167,13 +162,8 @@ describe("Add media", () => {
 						const rs = fs.createReadStream(filePath);
 						let resumeAt = 0;
 						rs.on('data', (data) => {
-							const p = kaltura.services.uploadToken.upload(
-								createdUploadToken.id,
-								data,
-								true,
-								rs.bytesRead === stats.size,
-								resumeAt,
-							).execute(client);
+							const p = kaltura.services.uploadToken.upload(createdUploadToken.id, data, true, rs.bytesRead === stats.size, resumeAt)
+								.execute(client);
 							uploads.push(p);
 							resumeAt += data.length;
 						});


### PR DESCRIPTION
In our project we need support for uploading a file in chunks without having to split the file in multiple parts.
