### PR TITLE
feat(node2): add proxy support to client

### DIFF
--- a/sources/node2/README.md
+++ b/sources/node2/README.md
@@ -9,6 +9,20 @@ You can install this client library using npm with:
 ```
 npm install kaltura-client 
 ```
+## Proxy settings for client
+If the Kaltura client has to be used behind a proxy, this can be set in the KalturaConfiguration by setting proxy
+to the url of the proxy. For example:
+
+```js
+const config = new kaltura.Configuration();
+    
+const proxyUrl = new url.URL('http://some.proxy.com');
+proxyUrl.username = 'user';
+proxyUrl.password = 'pass';
+    
+config.proxy = proxyUrl.toString();
+const client = new kaltura.Client(config);
+```
 
 ## Sanity Check
 - Copy config.template.json to config.json  and set partnerId, secret and serviceUrl

--- a/sources/node2/README.md
+++ b/sources/node2/README.md
@@ -16,7 +16,7 @@ to the url of the proxy. For example:
 ```js
 const config = new kaltura.Configuration();
     
-const proxyUrl = new url.URL('http://some.proxy.com');
+const proxyUrl = new URL('http://some.proxy.com');
 proxyUrl.username = 'user';
 proxyUrl.password = 'pass';
     

--- a/sources/node2/package.json
+++ b/sources/node2/package.json
@@ -28,11 +28,10 @@
   },
   "dependencies": {
     "md5": "*",
-    "url": "*",
     "path": "*",
     "http": "*",
     "https": "*",
-    "querystring": "*"
+    "request": "~2.88.0",
   },
   "devDependencies": {
     "shortid": "^2.2.8",


### PR DESCRIPTION
Introduces proxy support to the node2 client library by using the request library.
No new tests were written because in the way the tests are written it is not really possible unless there is an actual proxy set up.