### PR TITLE
Ruby HTTP[s] proxy support

### DIFF
--- a/sources/ruby/README
+++ b/sources/ruby/README
@@ -21,3 +21,16 @@ IMPORTANT: never run the tests of the client library against a production accoun
 Update kaltura.yml with your account information
 Change directory to kaltura/ruby
 Execute the command: rake test
+
+== HTTP[s] proxy support ==
+This client respects both the `https_proxy` and `http_proxy` ENV vars (https_proxy takes precedence).
+`http_proxy` should be set like so: proxy_hostname:proxy_port, for example:
+http_proxy='my_proxy:3128' 
+
+When initialising the Kaltura::KalturaConfiguration object, you may also set a proxy host, like so:
+ 
+    config = Kaltura::KalturaConfiguration.new()
+    config.http_proxy = http_proxy
+
+Doing that will override the values set in either ENV var.
+

--- a/sources/ruby/lib/kaltura_client_base.rb
+++ b/sources/ruby/lib/kaltura_client_base.rb
@@ -194,6 +194,16 @@ module Kaltura
 			}
 
 			log("request options: " + JSON.pretty_generate(options))
+                        if @config.http_proxy and !@config.http_proxy.empty?
+                          RestClient.proxy = @config.http_proxy
+                          log('Proxy server: ' + @config.http_proxy + ' will be used.')
+                        elsif ENV['https_proxy']
+                          RestClient.proxy = ENV['https_proxy']
+                          log('Proxy server: ' + ENV['https_proxy'] + ' will be used.')
+                        elsif ENV['http_proxy']
+                          RestClient.proxy = ENV['http_proxy']
+                          log('Proxy server: ' + ENV['http_proxy'] + ' will be used.')
+                        end
 			res = RestClient::Request.execute(options)
 
 			return res
@@ -474,6 +484,7 @@ module Kaltura
 	class KalturaConfiguration
 		attr_accessor :logger
 		attr_accessor :service_url
+		attr_accessor :http_proxy
 		attr_accessor :format
 		attr_accessor :timeout
 		attr_accessor :requestHeaders
@@ -490,6 +501,10 @@ module Kaltura
 
 		def service_url=(url)
 			@service_url = url.chomp('/')
+		end
+
+		def http_proxy=(proxy_host_port)
+			@http_proxy = proxy_host_port
 		end
 	end
 

--- a/sources/ruby/lib/kaltura_client_base.rb
+++ b/sources/ruby/lib/kaltura_client_base.rb
@@ -196,13 +196,13 @@ module Kaltura
 			log("request options: " + JSON.pretty_generate(options))
                         if @config.http_proxy and !@config.http_proxy.empty?
                           RestClient.proxy = @config.http_proxy
-                          log('Proxy server: ' + @config.http_proxy + ' will be used.')
+                          log('Proxy server: ' + @config.http_proxy + ' will be used (KalturaConfiguration::http_proxy was set).')
                         elsif ENV['https_proxy']
                           RestClient.proxy = ENV['https_proxy']
-                          log('Proxy server: ' + ENV['https_proxy'] + ' will be used.')
+                          log('Proxy server: ' + ENV['https_proxy'] + ' will be used (https_proxy ENV var is set).')
                         elsif ENV['http_proxy']
                           RestClient.proxy = ENV['http_proxy']
-                          log('Proxy server: ' + ENV['http_proxy'] + ' will be used.')
+                          log('Proxy server: ' + ENV['http_proxy'] + ' will be used (http_proxy ENV var is set).')
                         end
 			res = RestClient::Request.execute(options)
 

--- a/tests/ovp/ruby/kaltura.yml
+++ b/tests/ovp/ruby/kaltura.yml
@@ -4,4 +4,6 @@ test:
     administrator_secret: @YOUR_ADMIN_SECRET@
     secret: @YOUR_USER_SECRET@
     service_url: @SERVICE_URL@
+    # uncomment and set to point to your HTTP[s] proxy if needed
+    # http_proxy: http://localhost:3128
     timeout: 120

--- a/tests/ovp/ruby/test/configuration_test.rb
+++ b/tests/ovp/ruby/test/configuration_test.rb
@@ -52,6 +52,7 @@ class ConfigurationTest < Test::Unit::TestCase
         
     partner_id = config["test"]["partner_id"]
     service_url = config["test"]["service_url"]
+    http_proxy = config["test"]["http_proxy"]
     administrator_secret = config["test"]["administrator_secret"]
     timeout = config["test"]["timeout"]
     
@@ -59,6 +60,7 @@ class ConfigurationTest < Test::Unit::TestCase
 
     config = Kaltura::KalturaConfiguration.new()
     config.service_url = service_url
+    config.http_proxy = http_proxy
     config.logger = Logger.new(STDOUT)
     config.timeout = timeout
     

--- a/tests/ovp/ruby/test/test_helper.rb
+++ b/tests/ovp/ruby/test/test_helper.rb
@@ -44,11 +44,13 @@ class Test::Unit::TestCase
         
     partner_id = config_file["test"]["partner_id"]
     service_url = config_file["test"]["service_url"]
+    http_proxy = config_file["test"]["http_proxy"]
     administrator_secret = config_file["test"]["administrator_secret"]
     timeout = config_file["test"]["timeout"]
     
     config = Kaltura::KalturaConfiguration.new()
     config.service_url = service_url
+    config.http_proxy = http_proxy
     config.logger = Logger.new(STDOUT)
     config.timeout = timeout
     


### PR DESCRIPTION
This client now respects both the `https_proxy` and `http_proxy` ENV vars (https_proxy takes precedence).
`http_proxy` should be set like so: `proxy_hostname:proxy_port`, for example:
> http_proxy='my_proxy:3128' 

When initialising the Kaltura::KalturaConfiguration object, you may also set a proxy host, like so:

```ruby
    config = Kaltura::KalturaConfiguration.new()
    config.http_proxy = http_proxy
```

Doing that will override the values set in either ENV var.

