### PR TITLE
Call order incorrect

### DIFF
--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -402,7 +402,7 @@ abstract class ClientGeneratorFromXml
 		$this->outputPath = $outputPath;
 		$this->copyPath = $copyPath;
 
-		$this->addFile('agpl.txt', file_get_contents(__DIR__ . '/../sources/agpl.txt'), false);
+		$this->addFile('LICENSE.txt', file_get_contents(__DIR__ . '/../sources/agpl.txt'), false);
 	}
 
     public function setAdditionalSourcesPath($path)

--- a/lib/ClientGeneratorFromXml.php
+++ b/lib/ClientGeneratorFromXml.php
@@ -105,8 +105,6 @@ abstract class ClientGeneratorFromXml
 		$this->_licenseBuffer = file_get_contents(__DIR__ . '/../sources/license.txt');
 		$this->_licenseBuffer = str_replace('//', $this->getSingleLineCommentMarker(), $this->_licenseBuffer);
 		$this->_licenseBuffer = str_replace("\r\n", "\n", $this->_licenseBuffer);
-
-		$this->addFile('agpl.txt', file_get_contents(__DIR__ . '/../sources/agpl.txt'), false);
 	}
 
 	protected function shouldIncludeType($type)
@@ -403,6 +401,8 @@ abstract class ClientGeneratorFromXml
 	{
 		$this->outputPath = $outputPath;
 		$this->copyPath = $copyPath;
+
+		$this->addFile('agpl.txt', file_get_contents(__DIR__ . '/../sources/agpl.txt'), false);
 	}
 
     public function setAdditionalSourcesPath($path)


### PR DESCRIPTION
In `lib/ClientGeneratorFromXml.php` there is a call to `$this->addFile()` in the constructor, to make sure the license file is added to the output client-libs. `$this->addFile()` indirectly depends on the value of `$this->outputPath` which is always `null` at the time the Constructor gets called.
By moving the addition of the license file to the `$this->setOutputPath()` function this will actually work as intended!

The current code will try to write to `/agpl.txt` no matter what the output directory is set to.

I also changed the filename from `agpl.txt` to `LICENSE.txt` as it seems more fitting, but feel free to cherrypick.