### PR TITLE
log4j

### DIFF
--- a/sources/java2/pom.xml
+++ b/sources/java2/pom.xml
@@ -121,26 +121,17 @@
             <version>2.2.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.11.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
+	<dependency>
+	    <groupId>org.apache.logging.log4j</groupId>
+	    <artifactId>log4j-api</artifactId>
+	    <version>2.13.0</version>
+	</dependency>
+	<dependency>
+	    <groupId>org.apache.logging.log4j</groupId>
+	    <artifactId>log4j-core</artifactId>
+	    <version>2.13.0</version>
+	</dependency>
         <!-- JUnit for testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/sources/java2/src/main/java/com/kaltura/client/Logger.java
+++ b/sources/java2/src/main/java/com/kaltura/client/Logger.java
@@ -32,7 +32,7 @@ abstract public class Logger
 	// Creation & retrieval methods:
 	public static ILogger getLogger(String name)
 	{
-		return LoggerOut.getLogger(name);//  KalturaLoggerNull.getLogger(name);// KalturaLoggerLog4j.get(name);
+		return new LoggerLog4j(name);
 	}
 	
 	public static ILogger getLogger(Class<?> clazz)


### PR DESCRIPTION
Since log4j can also log to STDOUT and in fact, will do so with the current log4j2.xml, there's no justification for using the LoggerOut class, or at least, none that I can see.