### PR TITLE
fix unicode support in api requests

### DIFF
--- a/sources/node2/KalturaClientBase.js
+++ b/sources/node2/KalturaClientBase.js
@@ -311,7 +311,6 @@ class RequestBuilder extends kaltura.VolatileRequestData {
 			body = jsonBody;
 		}
 
-		options.headers['Content-Length'] = body.length;
 		options.body = body;
 
 		client.request(options, (err, response, data) => {


### PR DESCRIPTION
removed setting `Content-Length` header for requests. This is handled by `request` library and therefore redundant. Furthermore it was wrong since it was not taking into account the byte length of the body, only the string representation of the body which could differ when unicode characters are involved for example.

For reference here is where request is computing the `Content-Length` header:
https://github.com/request/request/blob/3c0cddc7c8eb60b470e9519da85896ed7ee0081e/request.js#L424