### PR TITLE
With some service-action pairs (such as ReportService.getCsvFromStringParams)...

### DIFF
--- a/sources/java2/README.txt
+++ b/sources/java2/README.txt
@@ -52,9 +52,24 @@ To build the API:
 
 == HTTP Proxy Support ==
 
-After initialising an object of the `Configuration` class, invoke the below methods:
+The following methods are supported:
+
+0. After initialising an object of the `Configuration` class, invoke the below methods:
 config.setProxy("proxy.host");
 config.setProxyPort(int_port);
+
+1. Set the following Java properties:
+- http_proxy
+- http_proxy_port
+
+2. Export the following ENV vars:
+- http_proxy
+- http_proxy_port
+
+=== Order of precedence ===
+- If proxy set on the client object, it will be used, otherwise:
+    - If Java properties are set and are valid, they will be used, otherwise:
+        - If ENV vars are set and are valid, they will be used
 
 
 == TESTING THE API CLIENT LIBRARY USING ECLIPSE ==

--- a/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
+++ b/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
@@ -248,10 +248,27 @@ public class APIOkRequestsExecutor implements RequestQueue {
 		logger.debug("Proxy host is: " + config.getProxy());
 		logger.debug("Proxy port is: " + config.getProxyPort());
 		builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(config.getProxy(), config.getProxyPort())));
+	}else if (System.getProperty("http_proxy") !=null && System.getProperty("http_proxy_port") !=null){
+		int proxy_port = 0;
+		String proxy_host = System.getProperty("http_proxy");
+		String proxy_error = "`http_proxy_port` Java property is set but its value is invalid, will be ignored.";
+	        try {
+		    proxy_port = Integer.parseInt(System.getProperty("http_proxy_port"));
+		} catch(NumberFormatException e) {
+		    logger.debug(proxy_error);
+		} catch(NullPointerException e) {
+		    logger.debug(proxy_error);
+		}
+		if (proxy_port > 0){
+		    logger.debug("Proxy host (taken from Java property - http_proxy) is: " + proxy_host);
+		    logger.debug("Proxy port (taken from Java property - http_proxy_port) is: " + proxy_port);
+		    builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxy_host, proxy_port)));
+		}
 	// if a proxy was configured at the Kaltura client level (using setProxy()), the ENV var is ignored
 	// This is meant as a fallback
 	}else if (System.getenv("http_proxy") !=null && System.getenv("http_proxy_port") !=null){
 		int proxy_port = 0;
+		String proxy_host = System.getenv("http_proxy");
 		String proxy_error = "`http_proxy_port` ENV var is set but its value is invalid, will be ignored.";
 		// make sure the port value can be cast to int
 	        try {
@@ -263,9 +280,9 @@ public class APIOkRequestsExecutor implements RequestQueue {
 		}
 		// if we haven't got a valid port, no proxy will be used.
 		if (proxy_port > 0){
-		    logger.debug("Proxy host (taken from ENV var - http_proxy): " + System.getenv("http_proxy"));
+		    logger.debug("Proxy host (taken from ENV var - http_proxy): " + proxy_host);
 		    logger.debug("Proxy port (taken from ENV var - http_proxy_port): " + proxy_port);
-		    builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(System.getenv("http_proxy"), proxy_port)));
+		    builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxy_host, proxy_port)));
 		}
 	}
 

--- a/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
+++ b/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
@@ -263,8 +263,8 @@ public class APIOkRequestsExecutor implements RequestQueue {
 		}
 		// if we haven't got a valid port, no proxy will be used.
 		if (proxy_port > 0){
-		    logger.debug("Proxy host is: " + System.getenv("http_proxy"));
-		    logger.debug("Proxy port is: " + proxy_port);
+		    logger.debug("Proxy host (taken from ENV var - http_proxy): " + System.getenv("http_proxy"));
+		    logger.debug("Proxy port (taken from ENV var - http_proxy_port): " + proxy_port);
 		    builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(System.getenv("http_proxy"), proxy_port)));
 		}
 	}

--- a/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
+++ b/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
@@ -248,6 +248,25 @@ public class APIOkRequestsExecutor implements RequestQueue {
 		logger.debug("Proxy host is: " + config.getProxy());
 		logger.debug("Proxy port is: " + config.getProxyPort());
 		builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(config.getProxy(), config.getProxyPort())));
+	// if a proxy was configured at the Kaltura client level (using setProxy()), the ENV var is ignored
+	// This is meant as a fallback
+	}else if (System.getenv("http_proxy") !=null && System.getenv("http_proxy_port") !=null){
+		int proxy_port = 0;
+		String proxy_error = "`http_proxy_port` ENV var is set but its value is invalid, will be ignored.";
+		// make sure the port value can be cast to int
+	        try {
+		    proxy_port = Integer.parseInt(System.getenv("http_proxy_port"));
+		} catch(NumberFormatException e) {
+		    logger.debug(proxy_error);
+		} catch(NullPointerException e) {
+		    logger.debug(proxy_error);
+		}
+		// if we haven't got a valid port, no proxy will be used.
+		if (proxy_port > 0){
+		    logger.debug("Proxy host is: " + System.getenv("http_proxy"));
+		    logger.debug("Proxy port is: " + proxy_port);
+		    builder.proxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(System.getenv("http_proxy"), proxy_port)));
+		}
 	}
 
         return builder;

--- a/sources/java2/src/main/java/com/kaltura/client/Configuration.java
+++ b/sources/java2/src/main/java/com/kaltura/client/Configuration.java
@@ -114,10 +114,12 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 
 	public void setProxy(String proxy) {
 		params.put(Proxy, proxy);
+		System.setProperty("http_proxy",proxy);
 	}
 
 	public void setProxyPort(int proxyPort) {
 		params.put(ProxyPort, proxyPort);
+		System.setProperty("http_proxy_port",String.valueOf(proxyPort));
 	}
 
 


### PR DESCRIPTION

.. the proxy config set on the client (by calling `setProxy()`) is not taken into account.

This really ought to be fixed but, as a fallback, this change will read the `http_proxy` and `http_proxy_port` ENV vars and use them if:
- No proxy config is found on the client
- They are correctly set (i.e port is a numeric value)