### PR TITLE
PSVAMB-28920: Go Client should not be OVP default

### DIFF
--- a/config/generator.all.ini
+++ b/config/generator.all.ini
@@ -11,7 +11,6 @@ php5full
 php5Zend
 php4
 csharp
-go
 ruby
 java
 android

--- a/config/generator.defaults.ini
+++ b/config/generator.defaults.ini
@@ -7,4 +7,3 @@ php5ZendHostedPages
 testsClient
 testme
 testmeDoc
-go


### PR DESCRIPTION
Broken in lib/GoClientGenerator.php +1099 - extractAllInheritanceClasses