### PR TITLE
Fix: Deprecated function: ksort(): Passing null to parameter #2 ($flags) of type int is deprecated

### DIFF
--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -444,7 +444,7 @@ class KalturaClientBase
 	 * @param int $flags
 	 * @return boolean
 	 */
-	protected function ksortRecursive(&$array, $flags = null) 
+	protected function ksortRecursive(&$array, $flags = SORT_REGULAR) 
 	{
 		ksort($array, $flags);
 		foreach($array as &$arr) {

--- a/sources/php53/library/Kaltura/Client/ApiException.php
+++ b/sources/php53/library/Kaltura/Client/ApiException.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ApiExceptionArg.php
+++ b/sources/php53/library/Kaltura/Client/ApiExceptionArg.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/Base.php
+++ b/sources/php53/library/Kaltura/Client/Base.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/Base.php
+++ b/sources/php53/library/Kaltura/Client/Base.php
@@ -265,7 +265,7 @@ class Base
 	 * @param int $flags
 	 * @return boolean
 	 */
-	protected function ksortRecursive(&$array, $flags = null)
+	protected function ksortRecursive(&$array, $flags = SORT_REGULAR)
 	{
 		ksort($array, $flags);
 		foreach($array as &$arr) {

--- a/sources/php53/library/Kaltura/Client/ClientException.php
+++ b/sources/php53/library/Kaltura/Client/ClientException.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/Configuration.php
+++ b/sources/php53/library/Kaltura/Client/Configuration.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/EnumBase.php
+++ b/sources/php53/library/Kaltura/Client/EnumBase.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ILogger.php
+++ b/sources/php53/library/Kaltura/Client/ILogger.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/IPlugin.php
+++ b/sources/php53/library/Kaltura/Client/IPlugin.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/php53/library/Kaltura/Client/MultiRequestSubResult.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/NullValue.php
+++ b/sources/php53/library/Kaltura/Client/NullValue.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ObjectBase.php
+++ b/sources/php53/library/Kaltura/Client/ObjectBase.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ParseUtils.php
+++ b/sources/php53/library/Kaltura/Client/ParseUtils.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/Plugin.php
+++ b/sources/php53/library/Kaltura/Client/Plugin.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ServiceActionCall.php
+++ b/sources/php53/library/Kaltura/Client/ServiceActionCall.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/sources/php53/library/Kaltura/Client/ServiceBase.php
+++ b/sources/php53/library/Kaltura/Client/ServiceBase.php
@@ -9,7 +9,7 @@
 // to do with audio, video, and animation what Wiki platfroms allow them to do with
 // text.
 //
-// Copyright (C) 2006-2011  Kaltura Inc.
+// Copyright (C) 2006-2022  Kaltura Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
`ksortRecursive()` is never actually called with a second param.
Nonetheless, instead of falling back to `null`, set to `$flags` to `SORT_REGULAR` which is the `ksort()` default.