### PR TITLE
Revert "partnerId specified twice in generateSession fields"

### DIFF
--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -450,7 +450,8 @@ class KalturaClient(object):
                         expiry=86400, privileges=''):
         rand = random.randint(0, 0x10000)
         expiry = int(time.time()) + expiry
-        fields = [partnerId, expiry, type_, rand, userId, privileges]
+        fields = [
+            partnerId, partnerId, expiry, type_, rand, userId, privileges]
         fields = [
             x if isinstance(x, six.binary_type)
             else six.text_type(x).encode(KalturaClient.ENCODING)


### PR DESCRIPTION
Reverts kaltura/clients-generator#769

Hi @cclauss ,

I've initially merged your pull and I can definitely see why you thought specifying the partnerId twice is a mistake; however, in actual fact, it isn't.
Please review https://github.com/kaltura/server/blob/Rigel-18.2.0/alpha/apps/kaltura/lib/request/kSessionBase.class.php#L219 to understand why.

Further, and I suspect this also threw you (I confess I was momentarily confused by this as well), after removing the additional `partnerId` member, the tests successfully passed but that's because the `generateSession()` method is only used as fallback, in the event the `PyCrypto` module cannot be imported, see: https://github.com/kaltura/KalturaGeneratedAPIClientsPython/blob/master/KalturaClient/tests/utils.py#L12-L19

In light of the above, I'm reverting this pull but thank you for your work (on this and other pulls).