### PR TITLE
Fix Python client

### DIFF
--- a/sources/python/requirements.txt
+++ b/sources/python/requirements.txt
@@ -1,5 +1,4 @@
 -e .
-pycrypto
 pytest
 pytest-cov
 setuptools
@@ -7,3 +6,4 @@ requests
 requests-toolbelt
 six
 pycryptodome
+lxml

--- a/tests/ovp/python/KalturaClient/tests/test_functional.py
+++ b/tests/ovp/python/KalturaClient/tests/test_functional.py
@@ -275,14 +275,8 @@ class MultiRequestTests(KalturaBaseTest):
         # used as the ks for next calls
         client.setKs(ks)
 
-        mixEntry = KalturaMixEntry()
-        mixEntry.setName(".Net Mix %s" % (testString,))
-        mixEntry.setEditorType(KalturaEditorType.SIMPLE)
 
         # Request 2
-        mixEntry = client.mixing.add(mixEntry)
-
-        # Request 3
         ulFile = getTestFile('DemoVideo.flv')
         uploadTokenId = client.media.upload(ulFile)
 
@@ -290,12 +284,12 @@ class MultiRequestTests(KalturaBaseTest):
         mediaEntry.setName("Media Entry For Mix %s" % (testString,))
         mediaEntry.setMediaType(KalturaMediaType.VIDEO)
 
-        # Request 4
+        # Request 3
         mediaEntry = client.media.addFromUploadedFile(
             mediaEntry, uploadTokenId)
 
-        # Request 5
-        client.mixing.appendMediaEntry(mixEntry.id, mediaEntry.id)
+        # Request 4
+        client.media.get(mediaEntry.id)
 
         response = client.doMultiRequest()
 
@@ -305,10 +299,9 @@ class MultiRequestTests(KalturaBaseTest):
 
         # when accessing the response object we will use an index and not the
         # response number (response number - 1)
-        assert(isinstance(response[1], KalturaMixEntry))
-        mixEntry = response[1]
+        assert(isinstance(response[2], KalturaMediaEntry))
 
-        print("The new mix entry id is: {}".format(mixEntry.id))
+        print("The new entry id is: {}".format(mediaEntry.id))
 
 
 def test_suite():


### PR DESCRIPTION
    - Fix XML parse error (observed when making multirequests) by using lxml with etree.XMLParser(encoding='ISO-8859-1', ns_clean=True, recover=True)
    - Use `list(resultXml)` rather than the deprecated `getchildren()`
    - Use pycryptodome rather than deprecated pycrypto
    - Depend on lxml
    - Fix `_AdvancedMultiRequestExample()`
    - Added `debug_requests_on()` and `debug_requests_off()` for easier debugging of HTTPs requests