### PR TITLE
SUP-29816: Exclude variables from type service that should be excluded

### DIFF
--- a/config/generator.ini
+++ b/config/generator.ini
@@ -101,6 +101,7 @@ generator = SwiftClientGenerator
 
 [php5Zend : public]
 generator = PhpZendClientGenerator
+include = metadata_metadataBatch.*, metadata_metadata.*, metadata_metadataprofile.*
 
 [php5ZendMediaSpace]
 generator = PhpZendClientGenerator


### PR DESCRIPTION
changed only in config/generator.ini