### PR TITLE
Fix PHP (7.4) Notice - trying to access array offset of null

### DIFF
--- a/sources/zend/Kaltura/Client/ClientBase.php
+++ b/sources/zend/Kaltura/Client/ClientBase.php
@@ -273,7 +273,9 @@ class Kaltura_Client_ClientBase
 			}
 		}
 
-		$this->resetRequest();
+		if(!$this->isMultiRequest()) {
+			$this->resetRequest();
+		}
 
 		$endTime = microtime (true);
 


### PR DESCRIPTION
`doMultiRequest` calls `resetRequest` at the end of the method, so there's no need to call it in `doQueue` while in multi-request mode.
Not only it's not necessary, it's causing a potential bug in `doMultiRequest`. In this line, for example:
```php
$ret[] = Kaltura_Client_ParseUtils::unmarshalObject($item, $this->multiRequestReturnType[$i]);
```

Since `multiRequestReturnType` has been reset as part of the `doQueue` execution, `$this->multiRequestReturnType` is `null`, and trying to access an array offset of `null` emits a PHP notice in PHP 7.4+.

This also aligns with the behavior of our C# client lib: https://github.com/kaltura/clients-generator/blob/Rigel-18.4.0/sources/csharp/KalturaClient/KalturaClientBase.cs#L241-L242
