### PR TITLE
feat(node-typescript): add getter method for default request options

### DIFF
--- a/sources/node-typescript/src/kaltura-client-service.ts
+++ b/sources/node-typescript/src/kaltura-client-service.ts
@@ -60,6 +60,10 @@ export class KalturaClient {
     this._defaultRequestOptions = new KalturaRequestOptions(args);
   }
 
+  public getDefaultRequestOptions(): KalturaRequestOptions {
+    return this._defaultRequestOptions;
+  }
+
   private _validateOptions(): Error | null {
     if (!this._options) {
       return new KalturaClientException('client::missing_options', 'cannot transmit request, missing client options (did you forgot to provide options manually?)');


### PR DESCRIPTION
The class has only setter methods for the private fields. This PR adds a getter method for default request options.
Usage: get the default KS of the client.