### PR TITLE
Avoid PHP deprecation errors

### DIFF
--- a/sources/php5/KalturaClientBase.php
+++ b/sources/php5/KalturaClientBase.php
@@ -48,20 +48,24 @@ class MultiRequestSubResult implements ArrayAccess
         return new MultiRequestSubResult($this->value . ':' . $name);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return true;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
-        return new MultiRequestSubResult($this->value . ':' . $offset);
+	    return new MultiRequestSubResult($this->value . ':' . $offset);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 	}


### PR DESCRIPTION
> Deprecated:  Return type of MultiRequestSubResult::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void

See https://www.php.net/manual/en/arrayaccess.offsetget.php#124324