### PR TITLE
fix(typescript): fix outdated peer dependency

### DIFF
--- a/sources/typescript/package-lock.json
+++ b/sources/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.2",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@types/node": "^14.14.33",
+        "@types/node": ">=14.14.33",
         "tslib": "^2.0.0"
       },
       "devDependencies": {

--- a/sources/typescript/package.json
+++ b/sources/typescript/package.json
@@ -35,7 +35,7 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "@types/node": "^14.14.33",
+    "@types/node": ">=14.14.33",
     "tslib": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` in the typescript client fails because of having a `@types/node@^14.14.33` peer dependency - all applications use node 16+.
Changed the dependency from `^14` to `>=14` to match modern node versions.