### PR TITLE
feat(node-typescript): EP recent changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ tests/config.ini
 
 # IDE
 .idea
+.vscode
 
-#Xcode
+# Xcode
 xcuserdata/
 tests/ovp/swift/Example/Tests/Pods/
 

--- a/lib/typescript/ClassesGenerator.php
+++ b/lib/typescript/ClassesGenerator.php
@@ -81,6 +81,17 @@ class ClassesGenerator extends TypescriptGeneratorBase
         $customProperties = array();
         $customProperties[] = $acceptedTypes;
 
+        if ($this->framework === 'node-typescript') {
+          $customHeaders = new stdClass();
+          $customHeaders->name = "customHeaders";
+          $customHeaders->localProperty = true;
+          $customHeaders->customDeclaration = "{ [headerKey: string]: string }";
+          $customHeaders->optional = true;
+          $customHeaders->type = KalturaServerTypes::Object;
+          $customHeaders->typeClassName = "KalturaObjectBase";
+          $customProperties[] = $customHeaders;
+        }
+
         $createClassArgs->properties = array_merge(
             $customProperties,
             $this->serverMetadata->requestSharedParameters
@@ -551,6 +562,9 @@ export class {$classTypeName} extends {$this->utils->ifExp($base, $base,'')} {
                     case "string":
                         $result->type = 's';
                         break;
+                    case "pojo":
+                      $result->type = 's';
+                      break;
                     default:
                         throw new Exception("toApplicationType: Unknown simple type {$typeClassName}");
                 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/kaltura/clients-generator#readme",
   "dependencies": {
     "copy-dir": "^0.4.0",
+    "form-data": "^4.0.0",
     "rimraf": "^2.6.3"
   }
 }

--- a/sources/node-typescript/gulpfile.js
+++ b/sources/node-typescript/gulpfile.js
@@ -60,6 +60,7 @@ function compileTS(opt) {
     .pipe($.sourcemaps.init()) // sourcemaps will be generated
     .pipe(opt.tsProject($.typescript.reporter.fullReporter(true)))
     .on('error', function (error) {
+      console.log('Gulp error:', error)
       process.exit(1);
     });
 

--- a/sources/node-typescript/package.json
+++ b/sources/node-typescript/package.json
@@ -42,9 +42,9 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "@types/node": "^16.11.1",
-    "debug": "^4.3.2",
-    "got": "^11.8.2",
+    "@types/node": "^18.11.18",
+    "form-data": "^4.0.0",
+    "got": "^11.8.3",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/sources/node-typescript/src/adapters/kaltura-file-request-adapter.ts
+++ b/sources/node-typescript/src/adapters/kaltura-file-request-adapter.ts
@@ -1,15 +1,43 @@
 import { KalturaFileRequest } from '../api/kaltura-file-request';
 import { KalturaRequestOptions } from '../api/kaltura-request-options';
-import { createEndpoint, prepareParameters } from './utils';
+import { createCancelableAction, createEndpoint, getHeaders, prepareParameters } from './utils';
 import { KalturaClientOptions } from '../kaltura-client-options';
+import { KalturaClientException } from '../api/kaltura-client-exception';
+import { KalturaAPIException } from '../api/kaltura-api-exception';
 import { CancelableAction } from '../cancelable-action';
 
-
 export class KalturaFileRequestAdapter {
-  public transmit(request: KalturaFileRequest, clientOptions: KalturaClientOptions, defaultRequestOptions: KalturaRequestOptions): CancelableAction<{ url: string }> {
+  public transmit(
+    request: KalturaFileRequest, 
+    clientOptions: KalturaClientOptions, 
+    defaultRequestOptions: KalturaRequestOptions
+  ): CancelableAction<string> {
     const parameters = prepareParameters(request, clientOptions, defaultRequestOptions);
-    const { service, action, ...queryparams } = parameters;
-    const endpointUrl = createEndpoint(request, clientOptions, service, action, queryparams);
-    return CancelableAction.resolve({ url: endpointUrl });
+    const { service, action, ...body } = parameters;
+    const { customHeaders } = defaultRequestOptions;
+    const endpoint = createEndpoint(request, clientOptions, service, action);
+
+    return createCancelableAction<string>({ endpoint, headers: getHeaders(customHeaders), body }, 'text')
+      .then(result => {
+        try {
+          const response = request.handleResponse(result);
+          if (response.error) {
+            throw response.error;
+          } else {
+            return response.result;
+          }
+        } catch (error) {
+          if (error instanceof KalturaClientException || error instanceof KalturaAPIException) {
+            throw error;
+          } else {
+            const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : null;
+            throw new KalturaClientException('client::response-unknown-error', errorMessage || 'Failed to parse response');
+          }
+        }
+      },
+      error => {
+        const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : null;
+        throw new KalturaClientException("client::request-network-error", errorMessage || 'Error connecting to server');
+      });
   }
 }

--- a/sources/node-typescript/src/adapters/kaltura-multi-request-adapter.ts
+++ b/sources/node-typescript/src/adapters/kaltura-multi-request-adapter.ts
@@ -11,9 +11,10 @@ export class KalturaMultiRequestAdapter {
   transmit(request: KalturaMultiRequest, clientOptions: KalturaClientOptions, defaultRequestOptions: KalturaRequestOptions): CancelableAction<KalturaMultiResponse> {
     const parameters = prepareParameters(request, clientOptions, defaultRequestOptions);
     const { service, action, ...body } = parameters;
+    const { customHeaders } = defaultRequestOptions;
     const endpoint = createEndpoint(request, clientOptions, service, action);
 
-    return <any>(createCancelableAction<KalturaMultiResponse>({ endpoint, headers: getHeaders(), body })
+    return <any>(createCancelableAction<KalturaMultiResponse>({ endpoint, headers: getHeaders(customHeaders), body })
       .then(result => {
         try {
           return request.handleResponse(result);

--- a/sources/node-typescript/src/adapters/kaltura-upload-request-adapter.ts
+++ b/sources/node-typescript/src/adapters/kaltura-upload-request-adapter.ts
@@ -1,93 +1,72 @@
 import { KalturaUploadRequest } from '../api/kaltura-upload-request';
-import { buildQuerystring, createEndpoint, prepareParameters } from './utils';
+import { createEndpoint, prepareParameters } from './utils';
 import { KalturaClientException } from '../api/kaltura-client-exception';
 import { KalturaRequestOptions } from '../api/kaltura-request-options';
 import { KalturaClientOptions } from '../kaltura-client-options';
 import { KalturaAPIException } from '../api/kaltura-api-exception';
 import { CancelableAction } from '../cancelable-action';
 import got from 'got';
-import * as dbg from 'debug'
+import * as FormData from 'form-data';
+import { Logger } from "../api/kaltura-logger";
 
-const debug = dbg('kaltura:adapter:upload')
-
-/*
- * WE DONT SUPPORT UPLOAD YET
- */
 interface UploadByChunksData {
-  enabled: boolean;
   resume: boolean;
   resumeAt: number;
   finalChunk: boolean;
 }
+
+const serviceStr = 'uploadtoken' as const
+const actionStr = 'upload' as const
+
 export class KalturaUploadRequestAdapter {
-  private _chunkUploadSupported(request: KalturaUploadRequest<any>): boolean {
-    // SUPPORTED BY BROWSER?
-    // Check if these features are support by the browser:
-    // - File object type
-    // - Blob object type
-    // - FileList object type
-    // - slicing files
-    const supportedByBrowser = false;
-    const supportedByRequest = request.supportChunkUpload();
-    const enabledInClient = !this.clientOptions.chunkFileDisabled;
-
-    return enabledInClient && supportedByBrowser && supportedByRequest;
-  }
-
   constructor(public clientOptions: KalturaClientOptions, public defaultRequestOptions: KalturaRequestOptions) {
-    // Need to catch outer client.request() for this, so logging also..
-    debug('"node-typescript-client" does not yet support uploading, you can use Kaltura typescript client (Web) or Kaltura node client for this.')
-    throw new Error('"node-typescript-client" does not yet support uploading, you can use Kaltura typescript client (Web) or Kaltura node client for this.')
+    /* noop */
   }
 
   transmit(request: KalturaUploadRequest<any>): CancelableAction<any> {
     return new CancelableAction((resolve, reject, action) => {
-      const uploadedFileSize = !isNaN(request.uploadedFileSize) && isFinite(request.uploadedFileSize) && request.uploadedFileSize > 0 ? request.uploadedFileSize : 0;
+      const uploadedFileSize = !isNaN(request.uploadedFileSize) && isFinite(request.uploadedFileSize) && request.uploadedFileSize > 0
+        ? request.uploadedFileSize
+        : 0;
       const data: UploadByChunksData = {
-        enabled: this._chunkUploadSupported(request),
         resume: !!uploadedFileSize,
         finalChunk: false,
         resumeAt: uploadedFileSize
       };
-
       let activeAction: CancelableAction<any>;
 
-      const handleChunkUploadError = reason => {
+      const handleChunkUploadError = (reason) => {
         activeAction = null;
         reject(reason);
-      };
+      }
 
-      const handleChunkUploadSuccess = result => {
-        if (!data.enabled || data.finalChunk) {
-          activeAction = null;
-
-          try {
-            const response = request.handleResponse(result);
-
-            if (response.error) {
-              reject(response.error);
-            } else {
-              resolve(response.result);
-            }
-          } catch (error) {
-            if (error instanceof KalturaClientException || error instanceof KalturaAPIException) {
-              reject(error);
-            } else {
-              const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : null;
-              reject(new KalturaClientException('client::response-unknown-error', errorMessage || 'Failed to parse response'));
-            }
-          }
-
-
-        } else {
+      const handleChunkUploadSuccess = (result) => {
+        if (!data.finalChunk) {
           activeAction = this._chunkUpload(request, data).then(handleChunkUploadSuccess, handleChunkUploadError);
+          return;
         }
-      };
 
-      activeAction = this._chunkUpload(request, data)
-        .then(handleChunkUploadSuccess, handleChunkUploadError);
+        activeAction = null;
+        try {
+          const response = request.handleResponse(result);
+          if (response.error) {
+            throw response.error;
+          } else {
+            resolve(response.result);
+          }
+        } catch (error) {
+          if (error instanceof KalturaClientException) {
+            reject(new KalturaClientException(error.message, error.code, { ...(error.args || {}), service: serviceStr, action: actionStr }));
+          } else if (error instanceof KalturaAPIException) {
+            reject(new KalturaAPIException(error.message, error.code, { ...(error.args || {}), service: serviceStr, action: actionStr }))
+          } else {
+            const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : null;
+            reject(new KalturaClientException('client::response-unknown-error', errorMessage || 'Failed to parse response', { service: serviceStr, action: actionStr }));
+          }
+        }
+      }
 
-
+      activeAction = this._chunkUpload(request, data).then(handleChunkUploadSuccess, handleChunkUploadError);
       return () => {
         if (activeAction) {
           activeAction.cancel();
@@ -97,121 +76,116 @@ export class KalturaUploadRequestAdapter {
     });
   }
 
-  private _getFormData(filePropertyName: string, fileName: string, fileChunk: File | Blob): FormData {
-    const result = new FormData();
-    result.append("fileName", fileName);
-    result.append(filePropertyName, fileChunk);
-    return result;
+  private async _getFormData(
+    { fileName, fileData, ks }: { fileName: string, fileData: Blob, ks:string }
+  ): Promise<FormData> {
+    const form = new FormData();
+    form.append('fileName', fileName)
+    form.append('ks', ks)
+    const ab = await fileData.arrayBuffer();
+    const buffer = Buffer.from(ab);
+    form.append('fileData', buffer, { contentType: fileData.type, filename: fileName })
+    return form;
   }
 
-  private _chunkUpload(request: KalturaUploadRequest<any>, uploadChunkData: UploadByChunksData): CancelableAction<any> {
-    return new CancelableAction((resolve, reject) => {
-      const parameters = prepareParameters(request, this.clientOptions, this.defaultRequestOptions);
-
-      let isComplete = false;
-      const { propertyName, file } = request.getFileInfo();
-      let data = this._getFormData(propertyName, file.name, file);
-
-      let fileStart = 0;
-
-      if (uploadChunkData.enabled) {
-        let actualChunkFileSize: number = null;
-        const userChunkFileSize = this.clientOptions ? this.clientOptions.chunkFileSize : null;
-
-        if (userChunkFileSize && Number.isFinite(userChunkFileSize) && !Number.isNaN(userChunkFileSize)) {
-          if (userChunkFileSize < 1e5) {
-            debug(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 100Kb. using minimal value 100Kb instead`);
-            actualChunkFileSize = 1e5;
-          } else {
-            debug(`using user requested chunk size '${userChunkFileSize}'`);
-            actualChunkFileSize = userChunkFileSize;
-          }
-        } else {
-          debug(`using default chunk size 5Mb`);
-          actualChunkFileSize = 5e6; // default
-        }
-
-        uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;
-
-        fileStart = uploadChunkData.resumeAt;
-        const fileEnd = uploadChunkData.finalChunk ? file.size : fileStart + actualChunkFileSize;
-
-        data = this._getFormData(propertyName, file.name, file.slice(fileStart, fileEnd, file.type));
-
-        parameters.resume = uploadChunkData.resume;
-        parameters.resumeAt = uploadChunkData.resumeAt;
-        parameters.finalChunk = uploadChunkData.finalChunk;
+  private _getChunkFileSize(): number {
+    const userChunkFileSize = this.clientOptions ? this.clientOptions.chunkFileSize : null;
+    let actualChunkFileSize = 5e6; // default 5 mb
+    if (userChunkFileSize && Number.isFinite(userChunkFileSize) && !Number.isNaN(userChunkFileSize)) {
+      if (userChunkFileSize < 1e5) {
+        Logger.warn(`user requested for invalid upload chunk size '${userChunkFileSize}'. minimal value 100Kb. using minimal value 100Kb instead`)
+        actualChunkFileSize = 1e5;
       } else {
-        debug(`chunk upload not supported by browser or by request. Uploading the file as-is`);
+        actualChunkFileSize = userChunkFileSize;
       }
+    }
+    Logger.info(`using chunk size of ${userChunkFileSize} bytes`)
+    return actualChunkFileSize
+  }
 
-      const { service, action, ...queryparams } = parameters;
-      const endpointUrl = createEndpoint(request, this.clientOptions, service, action, queryparams);
+  private async _prepareRequest(
+    request: KalturaUploadRequest<any>,
+    uploadChunkData: UploadByChunksData
+  ): Promise<{ endpointUrl: string, form: FormData, searchParams: URLSearchParams }> {
+    const actualChunkFileSize = this._getChunkFileSize();
+    const { file } = request.getFileInfo();
+    uploadChunkData.finalChunk = (file.size - uploadChunkData.resumeAt) <= actualChunkFileSize;
+    const fileStart = uploadChunkData.resumeAt;
+    const fileEnd = uploadChunkData.finalChunk ? file.size : fileStart + actualChunkFileSize;
 
-      const promWithData = got.post('https://httpbin.org/anything', {
-        json: {
-          hello: 'world'
-        }
-      }).json();
+    const form = await this._getFormData({
+      fileName: file.name,
+      fileData: file.slice(fileStart, fileEnd, file.type),
+      ks: this.defaultRequestOptions.ks
+    })
+    const { service, action, ks, ...params } = prepareParameters(request, this.clientOptions, this.defaultRequestOptions);
+    const endpointUrl = createEndpoint(request, this.clientOptions, service, action);
+    const searchParams = new URLSearchParams({
+      ...params,
+      resume: uploadChunkData.resume,
+      resumeAt: uploadChunkData.resumeAt,
+      finalChunk: uploadChunkData.finalChunk
+    })
+    return { endpointUrl, form, searchParams }
+  }
 
-      const xhr = new XMLHttpRequest();
+  private _chunkUpload(
+    request: KalturaUploadRequest<any>,
+    uploadChunkData: UploadByChunksData
+  ): CancelableAction<any> {
+    return new CancelableAction((resolve, reject) => {
+      let isComplete = false, isAborted = false
+      let xMe, xKalturaSession
+      let gotRequest
 
-      xhr.onreadystatechange = () => {
-        if (xhr.readyState === 4) {
-          if (isComplete) {
-            return;
+      this._prepareRequest(request, uploadChunkData).then((
+        { endpointUrl, form, searchParams }:{ endpointUrl: string, form: FormData, searchParams: URLSearchParams }
+      ) => {
+        if (isAborted) { return }
+        gotRequest = got.post(endpointUrl, { body: form, searchParams })
+        // save headers and parse response:
+        gotRequest.then(response => {
+          isComplete = true
+          xMe = response?.headers?.['x-me'] || ''
+          xKalturaSession = response?.headers?.['x-kaltura-session'] || ''
+          Logger.debug(`Kaltura response completed for: ${serviceStr}/${actionStr}, x-me: ${xMe}, x-kaltura-session: ${xKalturaSession}`)
+          return gotRequest.json()
+        })
+        // handle parsed response:
+        .then((parsedResponse: any) => {
+          if (parsedResponse?.objectType === 'KalturaAPIException') {
+            reject(new KalturaAPIException(parsedResponse.message, parsedResponse.code, { ...(parsedResponse.args || {}), service: serviceStr, action: actionStr }))
+            return
           }
-          isComplete = true;
-          let resp;
-
-          try {
-            if (xhr.status === 200) {
-              resp = JSON.parse(xhr.response);
-            } else {
-              resp = new KalturaClientException('client::upload-failure', xhr.responseText || 'failed to upload file');
-            }
-          } catch (e) {
-            resp = new KalturaClientException('client::upload-failure', e.message || 'failed to upload file')
+          if (parsedResponse.uploadedFileSize === undefined || parsedResponse.uploadedFileSize === null) {
+            reject(new KalturaClientException('client::upload-failure', `uploaded chunk of file failed, expected response with property 'uploadedFileSize'`, { service: serviceStr, action: actionStr }))
+            return
           }
-
-          if (resp instanceof Error) {
-            reject(resp);
-          } else {
-            if (uploadChunkData.enabled) {
-              if (typeof resp.uploadedFileSize === "undefined" || resp.uploadedFileSize === null) {
-                reject(new KalturaClientException('client::upload-failure', `uploaded chunk of file failed, expected response with property 'uploadedFileSize'`));
-                return;
-              } else if (!uploadChunkData.finalChunk) {
-                uploadChunkData.resumeAt = Number(resp.uploadedFileSize);
-                uploadChunkData.resume = true;
-              }
-            }
-
-            resolve(resp);
+          if (!uploadChunkData.finalChunk) {
+            uploadChunkData.resumeAt = Number(parsedResponse.uploadedFileSize)
+            uploadChunkData.resume = true
           }
-        }
-      };
-
-      const progressCallback = request._getProgressCallback();
-      if (progressCallback) {
-        xhr.upload.addEventListener("progress", e => {
-          if (e.lengthComputable) {
-            progressCallback.apply(request, [e.loaded + fileStart, file.size]);
-          } else {
-            // Unable to compute progress information since the total size is unknown
-          }
-        }, false);
-      }
-
-      xhr.open("POST", endpointUrl);
-      xhr.send(data);
+          resolve(parsedResponse);
+        })
+        // handle errors:
+        .catch(e => {
+          isComplete = true
+          xMe ||= e.response?.headers?.['x-me'] || ''
+          xKalturaSession ||= e.response?.headers?.['x-kaltura-session'] || ''
+          const msg = e.response?.body || e.message || 'failed to upload file'
+          const err = new KalturaClientException('client::upload-failure', msg);
+          Logger.error(`Kaltura response error: '${msg || ''}', for: ${serviceStr}/${actionStr}, x-me: ${xMe}, x-kaltura-session: ${xKalturaSession}`)
+          reject(err)
+        })
+      })
 
       return () => {
         if (!isComplete) {
           isComplete = true;
-          xhr.abort();
+          isAborted = true
+          gotRequest?.cancel();
         }
-      };
-    });
+      }
+    })
   }
 }

--- a/sources/node-typescript/src/api/kaltura-file-request.ts
+++ b/sources/node-typescript/src/api/kaltura-file-request.ts
@@ -2,10 +2,8 @@ import { KalturaRequest, KalturaRequestArgs } from './kaltura-request';
 
 export interface KalturaFileRequestArgs extends KalturaRequestArgs { }
 
-export class KalturaFileRequest extends KalturaRequest<{ url: string }> {
-
+export class KalturaFileRequest extends KalturaRequest<string> {
   constructor(data: KalturaFileRequestArgs) {
     super(data, { responseType: 'v', responseSubType: '', responseConstructor: null });
   }
-
 }

--- a/sources/node-typescript/src/api/kaltura-logger.ts
+++ b/sources/node-typescript/src/api/kaltura-logger.ts
@@ -1,0 +1,20 @@
+
+
+const Levels = ['verbose', 'debug', 'info', 'warn', 'error', 'fatal'] as const
+type TLevel = typeof Levels[number]
+
+const hostLogger = {
+  logger: null
+}
+
+const ClientLogger = {
+  get(target, prop) {
+    if(!Levels.includes(prop)) {
+      throw new Error('Invalid usage of Kaltura Logger')
+    }
+    return target.logger?.[prop] || (() => {})
+  }
+}
+
+export const Logger = new Proxy(hostLogger, ClientLogger);
+export const initializeLogger = (logger: Partial<Record<TLevel, (msg:string) => any>>): void => { hostLogger.logger = logger}

--- a/sources/node-typescript/src/api/kaltura-object-base.ts
+++ b/sources/node-typescript/src/api/kaltura-object-base.ts
@@ -1,6 +1,6 @@
 import { KalturaClientUtils } from "./kaltura-client-utils";
 import { KalturaTypesFactory } from './kaltura-types-factory';
-import * as dbg from 'debug'
+import { Logger } from './kaltura-logger'
 
 export type DependentProperty = { property: string, request: number, targetPath?: string[] };
 
@@ -20,8 +20,6 @@ export interface KalturaObjectBaseArgs {
   relatedObjects?: { [key: string]: KalturaObjectBase };
 }
 
-const debug = dbg('kaltura:base:object')
-
 export abstract class KalturaObjectBase {
 
   private _allowedEmptyArray: string[] = [];
@@ -34,9 +32,9 @@ export abstract class KalturaObjectBase {
     for (const property of properties) {
       const metadataProperty = metadata[property];
       if (!metadataProperty) {
-        debug(`ignore property '${property}' flagged to allow empty array as it doesn't not exists on type (did you set the right property in method 'allowEmptyArray'?)`);
+        Logger.debug(`ignore property '${property}' flagged to allow empty array as it doesn't not exists on type (did you set the right property in method 'allowEmptyArray'?)`)
       } else if (metadataProperty.type !== 'a') {
-        debug(`ignore property '${property}' flagged to allow empty array as it is not of type array (did you set the right property in method 'allowEmptyArray'?)`);
+        Logger.debug(`ignore property '${property}' flagged to allow empty array as it is not of type array (did you set the right property in method 'allowEmptyArray'?)`)
       } else {
         this._allowedEmptyArray.push(property);
       }
@@ -102,7 +100,7 @@ export abstract class KalturaObjectBase {
       });
     } catch (err) {
       // TODO [kaltura] should use logHandler
-      debug(err.message);
+      Logger.error(err.message)
       throw err;
     }
 
@@ -124,7 +122,7 @@ export abstract class KalturaObjectBase {
       });
     } catch (err) {
       // TODO [kaltura] should use logHandler
-      debug(err.message);
+      Logger.error(err.message)
       throw err;
     }
 
@@ -252,9 +250,9 @@ export abstract class KalturaObjectBase {
     }
 
     if (usedFallbackType && result) {
-      debug(`[kaltura-client]: Could not find object type '${objectType}', Falling back to '${fallbackObjectType}' object type. (Did you remember to set your accepted object types in the request “config.acceptedTypes” attribute?)`);
+      Logger.debug(`could not find object type '${objectType}', Falling back to '${fallbackObjectType}' object type. (Did you remember to set your accepted object types in the request “config.acceptedTypes” attribute?)`)
     } else if (!result) {
-      debug(`[kaltura-client]: Could not find object type '${objectType}'. (Did you remember to set your accepted object types in the request “config.acceptedTypes” attribute?)`);
+      Logger.debug(`could not find object type '${objectType}'. (Did you remember to set your accepted object types in the request “config.acceptedTypes” attribute?)`)
     }
 
     return result;

--- a/sources/node-typescript/src/api/kaltura-request-base.ts
+++ b/sources/node-typescript/src/api/kaltura-request-base.ts
@@ -1,8 +1,7 @@
 import { KalturaObjectBase, KalturaObjectBaseArgs } from './kaltura-object-base';
-import * as dbg from 'debug'
+import { Logger } from "./kaltura-logger";
 
 export interface KalturaRequestBaseArgs extends KalturaObjectBaseArgs { }
-const debug = dbg('kaltura:base:request')
 
 export class KalturaRequestBase extends KalturaObjectBase {
 
@@ -10,7 +9,7 @@ export class KalturaRequestBase extends KalturaObjectBase {
 
   setNetworkTag(tag: string): this {
     if (!tag || tag.length > 10) {
-      debug(`cannot set network tag longer than 10 characters. ignoring tag '${tag}`);
+      Logger.debug(`cannot set network tag longer than 10 characters. ignoring tag '${tag}`);
     } else {
       this._networkTag = tag;
     }

--- a/sources/node-typescript/src/api/kaltura-upload-request.ts
+++ b/sources/node-typescript/src/api/kaltura-upload-request.ts
@@ -1,14 +1,11 @@
 import { KalturaRequest, KalturaRequestArgs } from "./kaltura-request";
 import { KalturaObjectBase } from "./kaltura-object-base";
 
-export type ProgressCallback = (loaded: number, total: number) => void;
-
 export interface KalturaUploadRequestArgs extends KalturaRequestArgs {
   uploadedFileSize?: number;
 }
 
 export class KalturaUploadRequest<T> extends KalturaRequest<T> {
-  private _progressCallback: ProgressCallback;
   public uploadedFileSize: number = 0;
 
   constructor(data: KalturaUploadRequestArgs, { responseType, responseSubType, responseConstructor }: { responseType: string, responseSubType?: string, responseConstructor: { new(): KalturaObjectBase } }) {
@@ -16,29 +13,9 @@ export class KalturaUploadRequest<T> extends KalturaRequest<T> {
     this.uploadedFileSize = data.uploadedFileSize;
   }
 
-  setProgress(callback: ProgressCallback): this {
-    this._progressCallback = callback;
-    return this;
-  }
-
-  public _getProgressCallback(): ProgressCallback {
-    return this._progressCallback;
-  }
-
-  public supportChunkUpload(): boolean {
-    // chunk upload currently assume support according to request/reseponse properties. Should get this information from the client-generator directly.
-    const { properties } = this._getMetadata();
-    const responseSupportChunk = this._responseConstructor ? (new this._responseConstructor()).hasMetadataProperty("uploadedFileSize") : false;
-    return responseSupportChunk
-      && !!properties["resume"]
-      && !!properties["resumeAt"]
-      && !!properties["finalChunk"];
-  }
-
   public getFileInfo(): { file: File, propertyName: string } {
     const metadataProperties = this._getMetadata().properties;
     const filePropertyName = Object.keys(metadataProperties).find(propertyName => metadataProperties[propertyName].type === "f");
-
     return filePropertyName ? { propertyName: filePropertyName, file: this[filePropertyName] } : null;
   }
 

--- a/sources/node-typescript/src/kaltura-client-service.ts
+++ b/sources/node-typescript/src/kaltura-client-service.ts
@@ -81,8 +81,8 @@ export class KalturaClient {
   }
 
   public request<T>(request: KalturaRequest<T>): CancelableAction<T>;
-  public request<T>(request: KalturaFileRequest): CancelableAction<{ url: string }>;
-  public request<T>(request: KalturaRequest<T> | KalturaFileRequest): CancelableAction<T | { url: string }> {
+  public request<T>(request: KalturaFileRequest): CancelableAction<string>;
+  public request<T>(request: KalturaRequest<T> | KalturaFileRequest): CancelableAction<T|string> {
 
     const optionsViolationError = this._validateOptions();
 

--- a/sources/node-typescript/tsconfig.json
+++ b/sources/node-typescript/tsconfig.json
@@ -5,7 +5,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"importHelpers": true,
-		"lib": ["ES2020", "DOM"],
+		"lib": ["ES2021", "DOM"],
 		"module": "commonjs",
 		"noEmitHelpers": true,
 		"noImplicitAny": false,


### PR DESCRIPTION
**EP uses this branch for it's own changes, since Sites needs some of these changes and for being more orderly we want to merge these `battle tested changes:`**

* Supporting upload actions (with auto batch)
* Added `customHeaders` to kaltura-request-options creation
* Supporting File Requests Actions (some requests had missing support)
* Added global logger and informative error handling
* Merged with default [clients-generator](https://github.com/kaltura/clients-generator) branch
* Updated `npm` libs
* Limiting `got` version, since the new version is pure ESM and if we use it then the client user should probably also be pure ESM (in the future should switch to node-fetch)