### PR TITLE
KMS-27215 support unnamed response profile

### DIFF
--- a/sources/zend/Kaltura/Client/ParseUtils.php
+++ b/sources/zend/Kaltura/Client/ParseUtils.php
@@ -137,7 +137,11 @@ class Kaltura_Client_ParseUtils
 
 				if($attribute === 'relatedObjects') {
 					$object->relatedObjects = array();
-					$objectVars = get_object_vars($attributeValue);
+					if(is_object($attributeValue)) {
+						$objectVars = get_object_vars($attributeValue);
+					} else {
+						$objectVars = $attributeValue;
+					}
 					foreach($objectVars as $key => $relatedObject) {
 						$object->relatedObjects[$key] = self::jsObjectToClientObject($relatedObject);
 					}

--- a/tests/ovp/zend/tests/Test/ZendClientTester.php
+++ b/tests/ovp/zend/tests/Test/ZendClientTester.php
@@ -222,9 +222,46 @@ class ZendClientTester
 
 		$this->_client->setResponseProfile($responseProfile);
 		$result = $this->_client->media->get($entry->id);
+		$this->assertTrue(count($result->relatedObjects) > 0);
 		$this->assertTrue(isset($result->relatedObjects['thumbsOfEntry']));
 		$this->assertTrue(isset($result->relatedObjects['entryOwner']));
 		$this->assertTrue($result->relatedObjects['entryOwner']->objects[0]->id === $entry->userId);
+	}
+
+	public function testResponseProfileUnNamed() {
+		$entry = $this->addImageEntry();
+
+		$filter = new Kaltura_Client_Type_ThumbAssetFilter();
+		$userFilter = new Kaltura_Client_Type_UserFilter();
+
+		$resourceMapping = new Kaltura_Client_Type_ResponseProfileMapping();
+		$resourceMapping->filterProperty = 'entryIdEqual';
+		$resourceMapping->parentProperty = 'id';
+        
+		$userResourceMapping = new Kaltura_Client_Type_ResponseProfileMapping();
+		$userResourceMapping->filterProperty = 'idEqual';
+		$userResourceMapping->parentProperty = 'userId';
+
+		$thumbListResponseProfile = new Kaltura_Client_Type_ResponseProfile();
+		$thumbListResponseProfile->filter = $filter;
+		$thumbListResponseProfile->mappings = array($resourceMapping);
+
+		$userResponseProfile = new Kaltura_Client_Type_ResponseProfile();
+		$userResponseProfile->filter = $userFilter;
+		$userResponseProfile->mappings = [$userResourceMapping];
+
+		$responseProfile = new Kaltura_Client_Type_ResponseProfile();
+		$responseProfile->relatedProfiles = [
+			$userResponseProfile,
+			$thumbListResponseProfile,
+		];
+
+		$this->_client->setResponseProfile($responseProfile);
+		$result = $this->_client->media->get($entry->id);
+		$this->assertTrue(count($result->relatedObjects) > 0);
+		$this->assertTrue(isset($result->relatedObjects[0]));
+		$this->assertTrue(isset($result->relatedObjects[1]));
+		$this->assertTrue($result->relatedObjects[0]->objects[0]->id === $entry->userId);
 	}
 	
 	public function addImageEntry()


### PR DESCRIPTION
when related profiles do not have a name, the result is an array and not object, so get_object_vars cannot be used.