### PR TITLE
When testing KalturaClients, ensure that .ks has been set

### DIFF
--- a/tests/ovp/python/KalturaClient/tests/test_functional.py
+++ b/tests/ovp/python/KalturaClient/tests/test_functional.py
@@ -223,6 +223,7 @@ class MultiRequestTests(KalturaBaseTest):
         ks = self.client.session.start(ADMIN_SECRET, USER_NAME,
                                        KalturaSessionType.ADMIN,
                                        PARTNER_ID, 86400, "")
+        assert ks
         self.client.setKs(ks)
 
         listResult = self.client.baseEntry.list()
@@ -245,6 +246,7 @@ class MultiRequestTests(KalturaBaseTest):
         ks = self.client.session.start(
             ADMIN_SECRET, USER_NAME, KalturaSessionType.ADMIN, PARTNER_ID,
             86400, "")
+        assert ks
         self.client.setKs(ks)
 
         mediaEntry = self.client.media.get('invalid entry id')

--- a/tests/ovp/python/KalturaClient/tests/utils.py
+++ b/tests/ovp/python/KalturaClient/tests/utils.py
@@ -57,10 +57,13 @@ class KalturaBaseTest(unittest.TestCase):
         #(client session is enough when we do operations in a users scope)
         self.config = GetConfig()
         self.client = KalturaClient(self.config)
+        assert hasattr(self.client, "ks"), "New KalturaClients do not have a .ks attribute."
         self.ks = generateSessionFunction(ADMIN_SECRET, USER_NAME, 
                                              KalturaSessionType.ADMIN, PARTNER_ID, 
                                              86400, "disableentitlement")
-        self.client.setKs(self.ks)            
+        assert self.ks
+        self.client.setKs(self.ks)     
+        assert self.ks == self.client.ks
             
             
     def tearDown(self):

--- a/tests/ovp/python/KalturaClient/tests/utils.py
+++ b/tests/ovp/python/KalturaClient/tests/utils.py
@@ -62,7 +62,8 @@ class KalturaBaseTest(unittest.TestCase):
                                              KalturaSessionType.ADMIN, PARTNER_ID, 
                                              86400, "disableentitlement")
         assert self.ks
-        self.client.setKs(self.ks)     
+        self.client.setKs(self.ks)
+        assert self.ks == self.client.getKs()
         assert self.ks == self.client.ks
             
             


### PR DESCRIPTION
@jessp01 Your review please on this pull request and also
* [ ] #908 
* [ ] #909
* [ ] #950

Also, TravisCI seems to be failing at https://app.travis-ci.com/github/kaltura/KalturaGeneratedAPIClientsPython/builds
```
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
    with 'OpenSSL 1.0.2g  1 Mar 2016'. See: https://github.com/urllib3/urllib3/issues/2168
```
* https://github.com/urllib3/urllib3/issues/2168

This is because [TravisCI defaults to Ubuntu from 2016](https://docs.travis-ci.com/user/reference/linux/) so you need to add `dist: jammy` at the top of

https://github.com/kaltura/KalturaGeneratedAPIClientsPython/blob/dcac7d15f9654f4a2a81971d712d4ed04341f112/.travis.yml#L1