### PR TITLE
Utf8 and requests retries decorator in the python client

### DIFF
--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -388,13 +388,14 @@ class KalturaClient(object):
     def parsePostResult(self, postResult):
         self.log("result (xml): %s" % postResult)
         try:
-            #parser = etree.XMLParser(encoding='UTF-8', ns_clean=True, recover=True, huge_tree=True)
-            #resultXml = etree.fromstring(postResult, parser=parser)
+            # expect potentially large tree, attempt parsing while being forgiving and use utf-8 for encoding
             parser = etree.XMLParser(encoding='UTF-8', ns_clean=True, recover=True, huge_tree=True)
-            postResult = postResult.decode('utf-8', 'ignore')
-            # due to potential utf-8 decoding issues with binary data, if dataContent field exist, remove its contents:
+            # first decode ignoring decoding issues to remove dataContent
+            postResult = postResult.decode('utf-8', 'ignore') 
+            # due to potential utf-8 decoding issues with binary data, if dataContent field exist, remove its contents
             if '<dataContent>' in postResult:
                 postResult = re.sub(r'<dataContent>(.*?)</dataContent>', '<dataContent></dataContent>', postResult)
+            # encode the respose back, and then return the parsed result:
             postResult = postResult.encode('utf-8')
             resultXml = etree.fromstring(postResult, parser=parser)
         except etree.ParseError as e:

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -172,7 +172,7 @@ class KalturaClient(object):
         self.callsQueue = []
         self.requestHeaders = {}
         self.clientConfiguration = {
-            'clientTag': 'python-23-02-27',
+            'clientTag': 'python-@DATE@',
             'apiVersion': API_VERSION,
         }
         self.requestConfiguration = {}

--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -90,7 +90,7 @@ def retry_on_exception(max_retries=3, delay=1, backoff=2, exceptions=(Exception,
                     self = args[0]  # Assume that the function is a method of a class
                     msg = f"{str(error)}, Kaltura API retrying request in {mdelay} seconds..."
                     context = f'Function "{func.__name__}" failed on attempt {max_retries - mtries + 1} with args {args} and kwargs {kwargs}.'
-                    self.logger.critical(f'retrying function due to error: {msg} Context: {context}')
+                    self.log(f'retrying function due to error: {msg} Context: {context}')
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff


### PR DESCRIPTION
1. Improved `parsePostResult` to better handle utf-8 responses, and to drop `dataContent` from data service responses as it could often be binary or non utf-8 data, and added more robust lxml configuration to improve handling of large utf-8 responses.
2. Added a decorator that allows API requests retries in case of network or intermittent issues. Applied it to `doHttpRequest` and `parsePostResult` methods.