### PR TITLE
Initialize KalturaClient.ks to None when each instance is created

### DIFF
--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -147,6 +147,7 @@ class KalturaClient(object):
             'apiVersion': API_VERSION,
         }
         self.requestConfiguration = {}
+        self.ks = None
 
         self.config = config
         logger = self.config.getLogger()


### PR DESCRIPTION
It is customary in Python to initialize all class members in the `.__init__()` method.

Sometimes `KalturaClient.setKs()` fails to set `KalturaClient.ks` without raising an exception.  In our code, `client.setKs()` is called and no exception is raised but subsequently accessing `client.ks` raises an `AttributeError`.

It would be much more intuitive to be able to test `if client.ks:` anytime.