### PR TITLE
Fix Python README

### DIFF
--- a/sources/python/README.txt
+++ b/sources/python/README.txt
@@ -48,7 +48,7 @@ See KalturaClient/tests/README.txt
 == RELEASE NOTES ==
 
 Jan 2017 - Python 3 support. Replaced poster with requests.
-Sep 2015 - support JSON requests, compatible with Kaltura server version @VERSION@ and above. 
+Sep 2015 - support JSON requests
 Aug 2013 - the library was refactored to make it installable as a PyPI package.
 	This refactoring changed the way Kaltura client plugin modules are loaded -
 	before the change the metadata plugin (for example) was loaded by:


### PR DESCRIPTION
The release notes in the readme contain this line:

> `Sep 2015 - support JSON requests, compatible with Kaltura server version @VERSION@ and above.`

Since the `@VERSION@` token is used, it's replaced with whatever the current version of the backend is:

> `Sep 2015 - support JSON requests, compatible with Kaltura server version 20.6.0 and above.`

In this specific context, it implies that JSON is only supported from the most recent version, which is obviously wrong and might be misleading for some.

This PR simply removes the reference to a specific version:

> `Sep 2015 - support JSON requests`
