### PR TITLE
KMS-29057 fix deprecation

### DIFF
--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -32,7 +32,7 @@
  */
 class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 {
-    public $value;
+    private $value;
 
     function __construct($value)
 	{

--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -46,7 +46,7 @@ class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 
     function __get($name)
 	{
-        return new $this->value . ':' . $name;
+        return $this->value . ':' . $name;
 	}
 	
 	#[\ReturnTypeWillChange]

--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -34,17 +34,17 @@ class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 {
 	private $value;
 
-	function __construct($value)
+	public function __construct($value)
 	{
 		$this->value = $value;
 	}
 
-	function __toString()
+	public function __toString()
 	{
 		return '{' . $this->value . '}';
 	}
 
-	function __get($name)
+	public function __get($name)
 	{
 		return $this->value . ':' . $name;
 	}

--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -32,7 +32,7 @@
  */
 class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 {
-    private $value;
+    public $value;
 
     function __construct($value)
 	{
@@ -46,7 +46,7 @@ class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 
     function __get($name)
 	{
-        return new Kaltura_Client_MultiRequestSubResult($this->value . ':' . $name);
+        return new $this->value . ':' . $name;
 	}
 	
 	#[\ReturnTypeWillChange]

--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -32,6 +32,8 @@
  */
 class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 {
+    private $value;
+
     function __construct($value)
 	{
         $this->value = $value;

--- a/sources/zend/Kaltura/Client/MultiRequestSubResult.php
+++ b/sources/zend/Kaltura/Client/MultiRequestSubResult.php
@@ -32,23 +32,23 @@
  */
 class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 {
-    private $value;
+	private $value;
 
-    function __construct($value)
+	function __construct($value)
 	{
-        $this->value = $value;
-	}
-	
-    function __toString()
-	{
-        return '{' . $this->value . '}';
+		$this->value = $value;
 	}
 
-    function __get($name)
+	function __toString()
 	{
-        return $this->value . ':' . $name;
+		return '{' . $this->value . '}';
 	}
-	
+
+	function __get($name)
+	{
+		return $this->value . ':' . $name;
+	}
+
 	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
@@ -58,14 +58,14 @@ class Kaltura_Client_MultiRequestSubResult implements ArrayAccess
 	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
-	    return new Kaltura_Client_MultiRequestSubResult($this->value . ':' . $offset);
+		return new Kaltura_Client_MultiRequestSubResult($this->value . ':' . $offset);
 	}
 
 	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 	}
-	
+
 	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{

--- a/tests/ovp/zend/tests/Test/ZendClientTester.php
+++ b/tests/ovp/zend/tests/Test/ZendClientTester.php
@@ -172,16 +172,22 @@ class ZendClientTester
 		$entry = new Kaltura_Client_Type_BaseEntry();
 		$entry->name = "test entry 1";
 		$entry->tags = "test1";
-		$this->_client->baseEntry->add($entry);
+		$entryAddResult = $this->_client->baseEntry->add($entry);
+		$this->assertEqual((string)$entryAddResult, '{1:result}');
+		$this->assertEqual((int)$entryAddResult->value, 1);
 		$user = new Kaltura_Client_Type_User();
 		$user->id = "test1".rand(0, 10000000);
 		$user->type = Kaltura_Client_Enum_UserType::USER;
-		$this->_client->user->add($user);
+		$userAddResult = $this->_client->user->add($user);
+		$this->assertEqual((string)$userAddResult, '{2:result}');
+		$this->assertEqual((int)$userAddResult->value, 2);
 
 		$badUser = new Kaltura_Client_Type_User();
 		$badUser->id = "  test  1".rand(0, 10000000); // spaces in user ID not allowed, expected error
 		$badUser->type = Kaltura_Client_Enum_UserType::USER;
-		$this->_client->user->add($badUser);
+		$badUserAddResult = $this->_client->user->add($badUser);
+		$this->assertEqual((string)$badUserAddResult, '{3:result}');
+		$this->assertEqual((int)$badUserAddResult->value, 3);
 
 		$results = $this->_client->doMultiRequest();
 		$this->assertTrue($results[0]->name === $entry->name);


### PR DESCRIPTION
Fixes the following warnings:
```
PHP Warning:  Object of class Kaltura_Client_MultiRequestSubResult could not be converted to int
```
```
Deprecated: Creation of dynamic property Kaltura_Client_MultiRequestSubResult::$value is deprecated
```

Sample code:
```php
$client->startMultiRequest();

$entryGetResult = $client->entry->get('1_12345678');
$userGetResult = $client->user->get('user');

$entryGetResultIndex = (int)$entryGetResultIndex->value; // 1
$userGetResult = (int)$userGetResult->value; // 2

$client->doMultiRequest();
```