### PR TITLE
Java proxy fix for 20.14

### DIFF
--- a/sources/java2/README.txt
+++ b/sources/java2/README.txt
@@ -50,7 +50,7 @@ To build the API:
  - Build the project
 
 
-== HTTP Proxy Support ==
+== Proxy Support ==
 
 The following methods are supported:
 
@@ -58,13 +58,29 @@ The following methods are supported:
 config.setProxy("proxy.host");
 config.setProxyPort(int_port);
 
-1. Set the following Java properties:
-- http_proxy
-- http_proxy_port
+1. Proxy type can be toggle so it can connect either thru HTTP or SOCKS (https)
+If connection is thru an http proxy use 
+config.setProxyType("HTTP")
+If connection is thru https proxy use
+config.setProxyType("SOCKS")
 
-2. Export the following ENV vars:
+2. When a proxy requires basic authentication invoke the following methods:
+config.setProxyUsername("username");
+config.setProxyPassword("*****");
+
+3. Set the following Java properties:
 - http_proxy
 - http_proxy_port
+- http_proxy_type
+- http_proxy_username
+- http_proxy_password
+
+4. Export the following ENV vars:
+- http_proxy
+- http_proxy_port
+- http_proxy_type
+- http_proxy_username
+- http_proxy_password
 
 === Order of precedence ===
 - If proxy set on the client object, it will be used, otherwise:

--- a/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
+++ b/sources/java2/src/main/java/com/kaltura/client/APIOkRequestsExecutor.java
@@ -272,25 +272,6 @@ public class APIOkRequestsExecutor implements RequestQueue {
                                 config.getProxyPassword());
 
 
-        }else if (System.getProperty("http_proxy") !=null && System.getProperty("http_proxy_port") !=null){
-            logger.debug("Proxy configuration found from java properties");
-            this.configureProxy(builder,
-                System.getProperty("http_proxy"),
-                System.getProperty("http_proxy_port"),
-                System.getProperty("http_proxy_type"),
-                System.getProperty("http_proxy_username"),
-                System.getProperty("http_proxy_password"));
-
-        // if a proxy was configured at the Kaltura client level (using setProxy()), the ENV var is ignored
-        // This is meant as a fallback
-        }else if (System.getenv("http_proxy") !=null && System.getenv("http_proxy_port") !=null){
-            logger.debug("Proxy configuration found from ENV properties");
-            this.configureProxy(builder,
-                System.getenv("http_proxy"),
-                System.getenv("http_proxy_port"),
-                System.getenv("http_proxy_type"),
-                System.getenv("http_proxy_username"),
-                System.getenv("http_proxy_password"));
         }
 
         return builder;

--- a/sources/java2/src/main/java/com/kaltura/client/Configuration.java
+++ b/sources/java2/src/main/java/com/kaltura/client/Configuration.java
@@ -32,6 +32,7 @@ import com.kaltura.client.utils.request.ConnectionConfiguration;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.net.Proxy;
 
 /**
  * This class holds information needed by the Kaltura client to establish a session.
@@ -43,9 +44,12 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 
 	private static final long serialVersionUID = 2096581946429839651L;
 	
-	public final static String EndPoint = "endpoint";
-	public final static String Proxy = null;
-	public final static String ProxyPort = "0";
+	public final static String Endpoint = "endpoint";
+	public final static String PROXY = "proxy";
+	public final static String PROXY_PORT = "proxyPort";
+	public final static String PROXY_TYPE = "proxyType";
+	public final static String PROXY_USERNAME = "proxyUsername";
+	public final static String PROXY_PASSWORD = "proxyPassword";
 	public final static String ConnectTimeout = "connectTimeout";
 	public final static String ReadTimeout = "readTimeout";
 	public final static String WriteTimeout = "writeTimeout";
@@ -77,7 +81,8 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 		params.put(MaxRetry, config.getMaxRetry(2));
 		params.put(AcceptGzipEncoding, config.getAcceptGzipEncoding());
 		params.put(IgnoreSslDomainVerification, config.getIgnoreSslDomainVerification());
-		params.put(EndPoint, config.getEndpoint());
+		params.put(Endpoint, config.getEndpoint());
+		params.put(PROXY_TYPE, Proxy.Type.HTTP);
 	}
 
 	private void initDefaults() {
@@ -88,20 +93,37 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 		params.put(MaxRetry, 3);
 		params.put(AcceptGzipEncoding, false);
 		params.put(IgnoreSslDomainVerification, false);
-		params.put(EndPoint, "http://www.kaltura.com/");
+		params.put(Endpoint, "http://www.kaltura.com/");
+		params.put(PROXY_TYPE, Proxy.Type.HTTP);
 	}
 
 
 	public String getEndpoint() {
-		return (String) params.get(EndPoint);
+		return (String) params.get(Endpoint);
 	}
 
 	public String getProxy() {
-		return (String) params.get(Proxy);
+		return (String) params.get(PROXY);
 	}
 	public int getProxyPort() {
-		return (int) params.get(ProxyPort);
+		try {
+			return Integer.parseInt(params.get(PROXY_PORT).toString());	
+		} catch (ClassCastException e) {
+			return 0;
+		}
+		
 	}
+
+	public Proxy.Type getProxyType(){
+		return (Proxy.Type) params.get(PROXY_TYPE);
+	}
+	public String getProxyUsername(){
+		return (String) params.get(PROXY_USERNAME);
+	}
+	public String getProxyPassword(){
+		return (String) params.get(PROXY_PASSWORD);
+	}
+
 
 	@Override
 	public boolean getIgnoreSslDomainVerification() {
@@ -109,17 +131,39 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 	}
 
 	public void setEndpoint(String endpoint) {
-		this.params.put(EndPoint, endpoint);
+		this.params.put(endpoint, endpoint);
 	}
 
 	public void setProxy(String proxy) {
-		params.put(Proxy, proxy);
+		params.put(PROXY, proxy);
 		System.setProperty("http_proxy",proxy);
 	}
 
 	public void setProxyPort(int proxyPort) {
-		params.put(ProxyPort, proxyPort);
+		params.put(PROXY_PORT, String.valueOf(proxyPort));
 		System.setProperty("http_proxy_port",String.valueOf(proxyPort));
+	}
+
+	public void setProxyType(String proxyType) {
+		
+		if("sock".equalsIgnoreCase(proxyType) || "https".equalsIgnoreCase(proxyType)){
+			params.put(PROXY_TYPE, Proxy.Type.SOCKS);
+			System.setProperty("http_proxy_type",Proxy.Type.SOCKS.toString());
+		}else if("http".equalsIgnoreCase(proxyType)){
+			params.put(PROXY_TYPE, Proxy.Type.HTTP);
+			System.setProperty("http_proxy_type",Proxy.Type.HTTP.toString());
+		}
+		
+	}
+	
+	public void setProxyUsername(String proxyUsername) {
+		params.put(PROXY_USERNAME, proxyUsername);
+		System.setProperty("http_proxy_username",String.valueOf(proxyUsername));
+	}
+
+	public void setProxyPassword(String proxyPassword) {
+		params.put(PROXY_PASSWORD, proxyPassword);
+		System.setProperty("http_proxy_password",String.valueOf(proxyPassword));
 	}
 
 

--- a/sources/java2/src/main/java/com/kaltura/client/Configuration.java
+++ b/sources/java2/src/main/java/com/kaltura/client/Configuration.java
@@ -136,34 +136,28 @@ public class Configuration implements Serializable, ConnectionConfiguration {
 
 	public void setProxy(String proxy) {
 		params.put(PROXY, proxy);
-		System.setProperty("http_proxy",proxy);
 	}
 
 	public void setProxyPort(int proxyPort) {
 		params.put(PROXY_PORT, String.valueOf(proxyPort));
-		System.setProperty("http_proxy_port",String.valueOf(proxyPort));
 	}
 
 	public void setProxyType(String proxyType) {
 		
 		if("sock".equalsIgnoreCase(proxyType) || "https".equalsIgnoreCase(proxyType)){
 			params.put(PROXY_TYPE, Proxy.Type.SOCKS);
-			System.setProperty("http_proxy_type",Proxy.Type.SOCKS.toString());
 		}else if("http".equalsIgnoreCase(proxyType)){
 			params.put(PROXY_TYPE, Proxy.Type.HTTP);
-			System.setProperty("http_proxy_type",Proxy.Type.HTTP.toString());
 		}
 		
 	}
 	
 	public void setProxyUsername(String proxyUsername) {
 		params.put(PROXY_USERNAME, proxyUsername);
-		System.setProperty("http_proxy_username",String.valueOf(proxyUsername));
 	}
 
 	public void setProxyPassword(String proxyPassword) {
 		params.put(PROXY_PASSWORD, proxyPassword);
-		System.setProperty("http_proxy_password",String.valueOf(proxyPassword));
 	}
 
 

--- a/sources/java2/src/main/java/com/kaltura/client/utils/request/ConnectionConfiguration.java
+++ b/sources/java2/src/main/java/com/kaltura/client/utils/request/ConnectionConfiguration.java
@@ -1,5 +1,7 @@
 package com.kaltura.client.utils.request;
 
+import java.net.Proxy;
+
 /**
  * Created by tehilarozin on 30/10/2016.
  */
@@ -18,5 +20,8 @@ public interface ConnectionConfiguration {
     String getProxy();
     int getProxyPort();
 
+    Proxy.Type getProxyType();
+    String getProxyUsername();
+    String getProxyPassword();
 	boolean getIgnoreSslDomainVerification();
 }


### PR DESCRIPTION
Improve proxy server connection configuration for Kaltura. Added https support as well as a way of configuring username and password. Also figured out that System configuration is not needed. It was previously needed because of a bug in the configuration but I fixed that in the code. 