### PR TITLE
Remove retry on response parsing

### DIFF
--- a/sources/python/KalturaClient/Client.py
+++ b/sources/python/KalturaClient/Client.py
@@ -390,7 +390,6 @@ class KalturaClient(object):
         self.responseHeaders = r.headers
         return data
 
-    @retry_on_exception(max_retries=5, delay=5, backoff=2, exceptions=(KalturaException, KalturaClientException, UnicodeDecodeError, UnicodeEncodeError, requests.exceptions.RequestException))
     def parsePostResult(self, postResult):
         try:
             # Remove the content within <dataContent> tags to avoid utf8 decoding issues with binary data inside the xml


### PR DESCRIPTION
The response is constant, and it doesn't make sense to retry parsing.
The behavior with retry is that each API exception will return after ~60 seconds.