### PR TITLE
KMS-33858 add client tag to query param

### DIFF
--- a/sources/zend/Kaltura/Client/ClientBase.php
+++ b/sources/zend/Kaltura/Client/ClientBase.php
@@ -248,6 +248,19 @@ class Kaltura_Client_ClientBase
 		$signature = $this->signature($params);
 		$this->addParam($params, "kalsig", $signature);
 
+		$queryParams = [];
+		if ($this->clientConfiguration['clientTag'] ?? null) {
+			$queryParams[] = [
+				'clientTag' => $this->clientConfiguration['clientTag'],
+			];
+		}
+
+		$queryParams = array_merge([], ...$queryParams);
+
+		if (count($queryParams)) {
+			$url .= '?' . http_build_query($queryParams);
+		}
+
 		list($postResult, $errorCode, $error) = $this->doHttpRequest($url, $params, $files);
 
 		if ($error || ($errorCode != 200 ))

--- a/sources/zend/Kaltura/Client/ClientBase.php
+++ b/sources/zend/Kaltura/Client/ClientBase.php
@@ -248,16 +248,14 @@ class Kaltura_Client_ClientBase
 		$signature = $this->signature($params);
 		$this->addParam($params, "kalsig", $signature);
 
-		$queryParams = [];
-		if ($this->clientConfiguration['clientTag'] ?? null) {
-			$queryParams[] = [
-				'clientTag' => $this->clientConfiguration['clientTag'],
-			];
+		$queryParams = array();
+		if (!empty($this->clientConfiguration['clientTag']))
+		{
+			$queryParams['clientTag'] = $this->clientConfiguration['clientTag'];
 		}
 
-		$queryParams = array_merge([], ...$queryParams);
-
-		if (count($queryParams)) {
+		if (count($queryParams))
+		{
 			$url .= '?' . http_build_query($queryParams);
 		}
 


### PR DESCRIPTION
Consideration: should we use a shorter client tag for the query param? For example, KMC simply sends "kmcng".
With this PR, a typical API call will look like `https://[serviceUrl]/api_v3/service/[service]/action/[action]?clientTag=KMS+5.184.12%2C+build+0%3B6a7f29e91db79%3B56598d87ba93`.

Changing it to a shorter version, like "KMS [version]" will require introducing a new client configuration key like `shortClientTag`... Not sure how much it matters.